### PR TITLE
🩹 Fix recipe name with numbers highlighting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  // Disable bracket colorization for testing
+  "editor.bracketPairColorization.enabled": false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Recipe names with numbers highlight correctly
+
 ## [0.2.0] - 2024-03-16
 
 ### Added

--- a/syntaxes/just.tmLanguage.json
+++ b/syntaxes/just.tmLanguage.json
@@ -480,7 +480,7 @@
         },
         {
           "comment": "Recipe defintition",
-          "match": "^(@_|_@|@|_)?([a-zA-Z][a-zA-Z_\\-]*)(?:\\s+(.*))?\\s*(:)(.*)",
+          "match": "^(@_|_@|@|_)?([a-zA-Z][a-zA-Z0-9_\\-]*)(?:\\s+(.*))?\\s*(:)(.*)",
           "captures": {
             "1": {
               "name": "keyword.other.recipe.prefix.just"

--- a/syntaxes/just.tmLanguage.yml
+++ b/syntaxes/just.tmLanguage.yml
@@ -269,7 +269,7 @@ repository:
     patterns:
       - include: '#recipe-attributes'
       - comment: Recipe defintition
-        match: "^(@_|_@|@|_)?([a-zA-Z][a-zA-Z_\\-]*)(?:\\s+(.*))?\\s*(:)(.*)"
+        match: "^(@_|_@|@|_)?([a-zA-Z][a-zA-Z0-9_\\-]*)(?:\\s+(.*))?\\s*(:)(.*)"
         captures:
           '1':
             name: keyword.other.recipe.prefix.just


### PR DESCRIPTION
**Description:**

- Correctly highlights recipe names with numbers

**Testing/Screenshots:**

<img width="165" alt="Screenshot 2024-03-17 at 3 18 33 PM" src="https://github.com/nefrob/vscode-just/assets/25070989/f90932c0-5681-4eb4-be35-1f9372ce81f3">
