### PR TITLE
♻️ Refactor rule definitions and cleanup inconsistencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 
 ### Changed
 
+- Cleaned up inconsistent scope names for the same tokens
+
+### Fixed
+
+- Backticks in recipe definitions now highlight correctly
+
+### Changed
+
 - Updated tests
 
 ## [0.3.0] - 2024-06015

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `HEX` constants
+- Optional `?` operator for `import` and `mod`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 - `HEX` constants
 
-### Changed
-
-- Cleaned up inconsistent scope names for the same tokens
-
 ### Fixed
 
 - Backticks in recipe definitions now highlight correctly
@@ -17,6 +13,7 @@
 ### Changed
 
 - Updated tests
+- Cleaned up inconsistent scope names for the same tokens
 
 ## [0.3.0] - 2024-06015
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Since expressions can have deep nesting and we cannot tell the scope based on in
 
     will echo `{{ string }}` since braces within the string are escaped and part of the string's scope. Textmate can't handle this without a full parser, so will match on the first closing brace it finds.
 
+- Line breaking and expressions that span multiple lines may not highlight correctly. As a simple example
+
+    ```
+    foo param1 \
+        param2='foo':
+    echo {{param1}} {{param2}}
+    ```
+
 #### Publishing
 
 This extension is not available on open source marketplaces (for now). If you are using an open source build of VSCode, you might need to install the extension manually. To do so:

--- a/README.md
+++ b/README.md
@@ -34,13 +34,28 @@ Note: Unlike previous iterations of VSCode `just` extensions, this extension doe
 
 This extension does simple and/or best effort syntax highlighting. It is not intended to be 100% comprehensive, but rather provide a good enough experience for most users. That being said, if you find a bug or missing feature, please open an issue or a pull request.
 
--   Interpolation blocks, e.g. `{{ variable }}`, color all content as a string. Ideally it should match base `just` language highlighting, however limitations of regexs make comprehensive highlighting here complex or impossible for certain scenarios.
 
-- This extension is not available on open source marketplaces (for now). If you are using an open source build of VSCode, you might need to install the extension manually. To do so:
+#### Nesting and scoping
 
-    1. Navigate to the latest [release](https://github.com/nefrob/vscode-just/releases) and download the `.vsix` file.
-    2. Copy the file to your `.vscode/extensions` directory.
-    3. Install via the command line: `code --install-extension .vscode/extensions/vscode-just-X.Y.Z.vsix`
+Since expressions can have deep nesting and we cannot tell the scope based on indentation or other markers, we run into the following issues. These are limitations of TextMate grammars and is not easily fixable. 
+  
+-  Expression and recipe specific rules pollute the global repository scopes, meaning we apply `just` highlighting within recipe bodies. This means `just` keywords/operators/etc, like `if`, will highlight everywhere. This is necessary to highlight expressions correctly elsewhere.
+
+- Some nested expressions will break due to lack of awareness of depth and preemptively match a closing character. Ex. 
+
+    ```
+    echo {{ '{{ string }}' }}
+    ```
+
+    will echo `{{ string }}` since braces within the string are escaped and part of the string's scope. Textmate can't handle this without a full parser, so will match on the first closing brace it finds.
+
+#### Publishing
+
+This extension is not available on open source marketplaces (for now). If you are using an open source build of VSCode, you might need to install the extension manually. To do so:
+
+1. Navigate to the latest [release](https://github.com/nefrob/vscode-just/releases) and download the `.vsix` file.
+2. Copy the file to your `.vscode/extensions` directory.
+3. Install via the command line: `code --install-extension .vscode/extensions/vscode-just-X.Y.Z.vsix`
 
 ## Release Notes
 

--- a/syntaxes/just.tmLanguage.json
+++ b/syntaxes/just.tmLanguage.json
@@ -11,9 +11,6 @@
   "uuid": "8b0cfae0-229f-4688-a4b7-8b5c3db82855",
   "patterns": [
     {
-      "include": "#assignment"
-    },
-    {
       "include": "#comments"
     },
     {
@@ -24,6 +21,9 @@
     },
     {
       "include": "#alias"
+    },
+    {
+      "include": "#assignment"
     },
     {
       "include": "#builtins"
@@ -116,6 +116,64 @@
         }
       }
     },
+    "assignment": {
+      "patterns": [
+        {
+          "include": "#variable-assignment"
+        },
+        {
+          "include": "#setting-assignment"
+        }
+      ]
+    },
+    "variable-assignment": {
+      "patterns": [
+        {
+          "begin": "(?x) \n  ^\n  (?: (export) \\s+)?\n  ([a-zA-Z_][a-zA-Z0-9_-]*) \\s*\n  (:=)\n",
+          "end": "$",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.other.reserved.just"
+            },
+            "2": {
+              "name": "variable.other.just"
+            },
+            "3": {
+              "name": "keyword.operator.assignment.just"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#expression"
+            }
+          ]
+        }
+      ]
+    },
+    "setting-assignment": {
+      "patterns": [
+        {
+          "begin": "(?x) \n  ^\n  (set) \\s+\n  ([a-zA-Z_][a-zA-Z0-9_-]*) \\s*\n  (:=)?\n",
+          "end": "$",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.other.reserved.just"
+            },
+            "2": {
+              "name": "variable.other.just"
+            },
+            "3": {
+              "name": "keyword.operator.assignment.just"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#expression"
+            }
+          ]
+        }
+      ]
+    },
     "builtins": {
       "patterns": [
         {
@@ -171,7 +229,6 @@
     "keywords": {
       "patterns": [
         {
-          "comment": "Reserved",
           "match": "^(alias|export|import|mod|set)\\s+",
           "captures": {
             "1": {
@@ -223,40 +280,6 @@
           "captures": {
             "1": {
               "name": "keyword.operator.error-suppression.just"
-            }
-          }
-        }
-      ]
-    },
-    "assignment": {
-      "patterns": [
-        {
-          "comment": "Variable",
-          "match": "^(?:(export)\\s+)?([a-zA-Z_][a-zA-Z0-9_-]*)\\s*(:=)",
-          "captures": {
-            "1": {
-              "name": "keyword.other.assignment.just"
-            },
-            "2": {
-              "name": "variable.other.just"
-            },
-            "3": {
-              "name": "keyword.operator.assignment.just"
-            }
-          }
-        },
-        {
-          "comment": "Setting",
-          "match": "^(set)\\s+([a-zA-Z_][a-zA-Z0-9_-]*)\\s*(:=)?",
-          "captures": {
-            "1": {
-              "name": "keyword.other.reserved.just"
-            },
-            "2": {
-              "name": "variable.language.setting.just"
-            },
-            "3": {
-              "name": "keyword.operator.assignment.just"
             }
           }
         }

--- a/syntaxes/just.tmLanguage.json
+++ b/syntaxes/just.tmLanguage.json
@@ -17,6 +17,12 @@
       "include": "#comments"
     },
     {
+      "include": "#import"
+    },
+    {
+      "include": "#module"
+    },
+    {
       "include": "#alias"
     },
     {
@@ -56,6 +62,43 @@
         {
           "name": "comment.line.number-sign.just",
           "match": "#([^!].*)$"
+        }
+      ]
+    },
+    "import": {
+      "begin": "(?x)\n  ^\n  (import)\n  (\\?)? \\s+\n",
+      "end": "$",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.reserved.just"
+        },
+        "2": {
+          "name": "keyword.operator.optional.just"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#strings"
+        }
+      ]
+    },
+    "module": {
+      "begin": "(?x)\n  ^\n  (mod)\n  (\\?)? \\s+\n  ([a-zA-Z_][a-zA-Z0-9_-]*)\n  (?=[$\\s])\n",
+      "end": "$",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.reserved.just"
+        },
+        "2": {
+          "name": "keyword.operator.optional.just"
+        },
+        "3": {
+          "name": "variable.name.module.just"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#strings"
         }
       ]
     },

--- a/syntaxes/just.tmLanguage.json
+++ b/syntaxes/just.tmLanguage.json
@@ -566,7 +566,7 @@
         "5": {
           "patterns": [
             {
-              "include": "#inline-shell"
+              "include": "#backtick"
             }
           ]
         },
@@ -604,7 +604,7 @@
                       "include": "#constants"
                     },
                     {
-                      "include": "#inline-shell"
+                      "include": "#backtick"
                     },
                     {
                       "include": "#keywords"
@@ -662,9 +662,7 @@
         }
       ]
     },
-    "parenthesis-block": {
-      "begin": "\\(",
-      "end": "\\)",
+    "expression": {
       "patterns": [
         {
           "include": "#builtins"
@@ -683,6 +681,15 @@
         },
         {
           "include": "#strings"
+        }
+      ]
+    },
+    "parenthesis-block": {
+      "begin": "\\(",
+      "end": "\\)",
+      "patterns": [
+        {
+          "include": "#expression"
         }
       ]
     }

--- a/syntaxes/just.tmLanguage.json
+++ b/syntaxes/just.tmLanguage.json
@@ -2,7 +2,11 @@
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "Just",
   "scopeName": "source.just",
-  "fileTypes": ["just", "justfile", "Justfile"],
+  "fileTypes": [
+    "just",
+    "justfile",
+    "Justfile"
+  ],
   "firstLineMatch": "#![\\s\\t]*\\/.*\\just\\b",
   "uuid": "8b0cfae0-229f-4688-a4b7-8b5c3db82855",
   "patterns": [
@@ -11,6 +15,9 @@
     },
     {
       "include": "#comments"
+    },
+    {
+      "include": "#alias"
     },
     {
       "include": "#constants"
@@ -51,6 +58,23 @@
           "match": "#([^!].*)$"
         }
       ]
+    },
+    "alias": {
+      "match": "(?x)\n  ^\n  (alias) \\s+ \n  ([a-zA-Z_][a-zA-Z0-9_-]*) \\s* \n  (:=) \\s* \n  ([a-zA-Z_][a-zA-Z0-9_-]*)\n",
+      "captures": {
+        "1": {
+          "name": "keyword.other.reserved.just"
+        },
+        "2": {
+          "name": "variable.other.just"
+        },
+        "3": {
+          "name": "keyword.operator.assignment.just"
+        },
+        "4": {
+          "name": "variable.other.just"
+        }
+      }
     },
     "constants": {
       "patterns": [
@@ -166,7 +190,7 @@
       "patterns": [
         {
           "comment": "Variable",
-          "match": "^(?:(alias|export)\\s+)?([a-zA-Z_][a-zA-Z0-9_-]*)\\s*(:=)",
+          "match": "^(?:(export)\\s+)?([a-zA-Z_][a-zA-Z0-9_-]*)\\s*(:=)",
           "captures": {
             "1": {
               "name": "keyword.other.assignment.just"
@@ -596,32 +620,28 @@
       ]
     },
     "parenthesis-block": {
-      "comment": "Any block of just code surrounded by (...)",
-      "match": "\\((.*?)\\)",
-      "captures": {
-        "1": {
-          "patterns": [
-            {
-              "include": "#builtins"
-            },
-            {
-              "include": "#constants"
-            },
-            {
-              "include": "#keywords"
-            },
-            {
-              "include": "#operators"
-            },
-            {
-              "include": "#backtick"
-            },
-            {
-              "include": "#strings"
-            }
-          ]
+      "begin": "\\(",
+      "end": "\\)",
+      "patterns": [
+        {
+          "include": "#builtins"
+        },
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#keywords"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#backtick"
+        },
+        {
+          "include": "#strings"
         }
-      }
+      ]
     }
   }
 }

--- a/syntaxes/just.tmLanguage.json
+++ b/syntaxes/just.tmLanguage.json
@@ -69,7 +69,7 @@
           "name": "keyword.other.reserved.just"
         },
         "2": {
-          "name": "keyword.operator.optional.just"
+          "name": "punctuation.optional.just"
         }
       },
       "patterns": [
@@ -86,7 +86,7 @@
           "name": "keyword.other.reserved.just"
         },
         "2": {
-          "name": "keyword.operator.optional.just"
+          "name": "punctuation.optional.just"
         },
         "3": {
           "name": "variable.name.module.just"

--- a/syntaxes/just.tmLanguage.json
+++ b/syntaxes/just.tmLanguage.json
@@ -26,16 +26,13 @@
       "include": "#alias"
     },
     {
-      "include": "#constants"
+      "include": "#builtins"
     },
     {
       "include": "#keywords"
     },
     {
       "include": "#operators"
-    },
-    {
-      "include": "#builtins"
     },
     {
       "include": "#backtick"
@@ -119,14 +116,25 @@
         }
       }
     },
-    "constants": {
+    "builtins": {
       "patterns": [
         {
           "name": "constant.language.hex.just",
           "match": "\\b(HEX|HEXLOWER|HEXUPPER)\\b"
         },
         {
+          "include": "#builtin-functions"
+        },
+        {
           "include": "#literal"
+        }
+      ]
+    },
+    "builtin-functions": {
+      "patterns": [
+        {
+          "name": "support.function.builtin.just",
+          "match": "(?x) \\b(\n  arch|num_cpus|os|os_family|shell|env_var|env_var_or_default|env|\n  is_dependency|invocation_directory|invocation_directory_native|\n  justfile|justfile_directory|just_executable|just_pid|source_file|\n  source_directory|module_file|module_directory|append|prepend|\n  encode_uri_component|quote|replace|replace_regex|trim|trim_end|\n  trim_end_match|trim_end_matches|trim_start|trim_start_match|\n  trim_start_matches|capitalize|kebabcase|lowercamelcase|lowercase|\n  shoutykebabcase|shoutysnakecase|snakecase|titlecase|uppercamelcase|\n  uppercase|absolute_path|blake3|blake3_file|canonicalize|extension|\n  file_name|file_stem|parent_directory|without_extension|clean|join|\n  path_exists|error|assert|sha256|sha256_file|uuid|choose|datetime|\n  datetime_utc|semver_matches|cache_directory|config_directory|\n  config_local_directory|data_directory|data_local_directory|\n  executable_directory|home_directory\n)\\b\n"
         }
       ]
     },
@@ -217,15 +225,6 @@
               "name": "keyword.operator.error-suppression.just"
             }
           }
-        }
-      ]
-    },
-    "builtins": {
-      "patterns": [
-        {
-          "commment": "Functions",
-          "name": "support.function.builtin.just",
-          "match": "\\b(arch|num_cpus|os|os_family|shell|env_var|env_var_or_default|env|is_dependency|invocation_directory|invocation_directory_native|justfile|justfile_directory|just_executable|just_pid|source_file|source_directory|module_file|module_directory|append|prepend|encode_uri_component|quote|replace|replace_regex|trim|trim_end|trim_end_match|trim_end_matches|trim_start|trim_start_match|trim_start_matches|capitalize|kebabcase|lowercamelcase|lowercase|shoutykebabcase|shoutysnakecase|snakecase|titlecase|uppercamelcase|uppercase|absolute_path|blake3|blake3_file|canonicalize|extension|file_name|file_stem|parent_directory|without_extension|clean|join|path_exists|error|assert|sha256|sha256_file|uuid|choose|datetime|datetime_utc|semver_matches|cache_directory|config_directory|config_local_directory|data_directory|data_local_directory|executable_directory|home_directory)\\b"
         }
       ]
     },
@@ -475,9 +474,6 @@
             "2": {
               "patterns": [
                 {
-                  "include": "#constants"
-                },
-                {
                   "include": "#keywords"
                 },
                 {
@@ -601,9 +597,6 @@
                       "include": "#builtin-functions"
                     },
                     {
-                      "include": "#constants"
-                    },
-                    {
                       "include": "#backtick"
                     },
                     {
@@ -666,9 +659,6 @@
       "patterns": [
         {
           "include": "#builtins"
-        },
-        {
-          "include": "#constants"
         },
         {
           "include": "#keywords"

--- a/syntaxes/just.tmLanguage.json
+++ b/syntaxes/just.tmLanguage.json
@@ -32,25 +32,28 @@
       "include": "#keywords"
     },
     {
-      "include": "#operators"
+      "include": "#expression-operators"
     },
     {
       "include": "#backtick"
     },
     {
-      "include": "#embedded-languages"
-    },
-    {
       "include": "#strings"
     },
     {
-      "include": "#escaping"
+      "include": "#parenthesis"
     },
     {
       "include": "#recipes"
     },
     {
-      "include": "#parenthesis"
+      "include": "#recipe-operators"
+    },
+    {
+      "include": "#embedded-languages"
+    },
+    {
+      "include": "#escaping"
     }
   ],
   "repository": {
@@ -186,7 +189,7 @@
           "include": "#control-keywords"
         },
         {
-          "include": "#operators"
+          "include": "#expression-operators"
         },
         {
           "include": "#parenthesis"
@@ -290,45 +293,23 @@
         }
       ]
     },
-    "operators": {
+    "expression-operators": {
       "patterns": [
         {
-          "comment": "Path join",
           "name": "keyword.operator.path-join.just",
           "match": "\\/"
         },
         {
-          "comment": "Concatenation",
           "name": "keyword.operator.concat.just",
           "match": "\\+"
         },
         {
-          "comment": "And",
           "name": "keyword.operator.and.just",
           "match": "&&"
         },
         {
-          "comment": "Equality",
           "name": "keyword.operator.equality.just",
           "match": "(\\=\\=|\\=\\~|\\!\\=)"
-        },
-        {
-          "comment": "Quiet",
-          "match": "^\\s+(@)",
-          "captures": {
-            "1": {
-              "name": "keyword.operator.quiet.just"
-            }
-          }
-        },
-        {
-          "comment": "Error suppression",
-          "match": "^\\s+(\\-)",
-          "captures": {
-            "1": {
-              "name": "keyword.operator.error-suppression.just"
-            }
-          }
         }
       ]
     },
@@ -374,65 +355,6 @@
               "name": "string.interpolated.just"
             }
           }
-        }
-      ]
-    },
-    "embedded-languages": {
-      "patterns": [
-        {
-          "comment": "JavaScript",
-          "begin": "^\\s+#!/usr/bin/env\\s+node.*$",
-          "end": "^$",
-          "contentName": "source.js",
-          "patterns": [
-            {
-              "include": "source.js"
-            }
-          ]
-        },
-        {
-          "comment": "Perl",
-          "begin": "^\\s+#!/usr/bin/env\\s+perl.*$",
-          "end": "^$",
-          "contentName": "source.perl",
-          "patterns": [
-            {
-              "include": "source.perl"
-            }
-          ]
-        },
-        {
-          "comment": "Python",
-          "begin": "^\\s+#!/usr/bin/env\\s+python.*$",
-          "end": "^$",
-          "contentName": "source.python",
-          "patterns": [
-            {
-              "include": "source.python"
-            }
-          ]
-        },
-        {
-          "comment": "Ruby",
-          "begin": "^\\s+#!/usr/bin/env\\s+ruby.*$",
-          "end": "^$",
-          "contentName": "source.ruby",
-          "patterns": [
-            {
-              "include": "source.ruby"
-            }
-          ]
-        },
-        {
-          "comment": "Shell",
-          "begin": "^\\s+#!/usr/bin/env\\s+(sh|bash|zsh|fish).*$",
-          "end": "^$",
-          "contentName": "source.shell",
-          "patterns": [
-            {
-              "include": "source.shell"
-            }
-          ]
         }
       ]
     },
@@ -555,11 +477,72 @@
         }
       ]
     },
+    "recipes": {
+      "patterns": [
+        {
+          "match": "(?x)\n  ^\n  (@_|_@|@|_)?\n  ([a-zA-Z][a-zA-Z0-9_\\-]*)\n  (?: \\s+ (.*?) )?\n  \\s* (:)\n  (.*)\n",
+          "captures": {
+            "1": {
+              "name": "keyword.other.recipe.prefix.just"
+            },
+            "2": {
+              "name": "entity.name.function.just"
+            },
+            "3": {
+              "patterns": [
+                {
+                  "include": "#recipe-params"
+                }
+              ]
+            },
+            "4": {
+              "name": "keyword.operator.recipe.end.just"
+            },
+            "5": {
+              "patterns": [
+                {
+                  "include": "#recipe-dependencies"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "include": "#recipe-operators"
+        },
+        {
+          "include": "#recipe-attributes"
+        },
+        {
+          "include": "#embedded-languages"
+        }
+      ]
+    },
+    "recipe-operators": {
+      "patterns": [
+        {
+          "match": "^\\s+(@)",
+          "captures": {
+            "1": {
+              "name": "keyword.operator.quiet.just"
+            }
+          }
+        },
+        {
+          "match": "^\\s+(\\-)",
+          "captures": {
+            "1": {
+              "name": "keyword.operator.error-suppression.just"
+            }
+          }
+        }
+      ]
+    },
     "recipe-attributes": {
       "patterns": [
         {
           "comment": "Multiple recipe attributes",
-          "match": "^\\[([a-zA-z\\-]+)\\s*(?:,(\\s*[a-zA-z\\-]+\\s*))*]\\s*$",
+          "match": "(?x)\n  ^\n  \\[ \n    ([a-zA-z\\-]+) \\s*\n    (?: , ( \\s* [a-zA-z\\-]+ \\s* ) )*\n  ] \\s*\n  $\n",
           "captures": {
             "1": {
               "name": "support.function.system.just"
@@ -571,7 +554,7 @@
         },
         {
           "comment": "Recipe attribute with value",
-          "match": "^\\[([a-zA-z\\-]+)(?:(?:(:)(.*?))|(\\((.*?)\\)))?]\\s*$",
+          "match": "(?x)\n  ^\n  \\[\n    ([a-zA-z\\-]+)\n    (?: \n      (?: (:) (.*?) ) | (\\( (.*?) \\))\n    )?\n  ] \\s*\n  $\n",
           "captures": {
             "1": {
               "name": "support.function.system.just"
@@ -599,7 +582,7 @@
     },
     "recipe-params": {
       "comment": "Recipe parameters",
-      "match": "(?:(\\+|\\*|\\$)?([a-zA-Z_][a-zA-Z_0-9]*)(?:(=)(?:[a-zA-Z_][a-zA-Z_0-9]*|(\".*?\"|'.*?')|(`.*?`)|(\\((?:[^()]+|\\([^)]*\\))*\\))))?)",
+      "match": "(?x)\n  (?: \n    (\\+|\\*|\\$)?\n    ([a-zA-Z_][a-zA-Z_0-9]*\n  )\n  (?:\n    (=)\n    (?: \n      [a-zA-Z_][a-zA-Z_0-9]* \n      | (\\\".*?\\\" | '.*?') \n      | (`.*?`) \n      | ( \\( \n          (?: \n            [^\\(\\)]+ \n            | \\( [^)]* \\)\n          )* \\) ) \n        ) \n    )?\n  )\n",
       "captures": {
         "1": {
           "name": "keyword.other.recipe.variadic.just"
@@ -635,7 +618,7 @@
     },
     "recipe-dependencies": {
       "comment": "Recipe dependencies",
-      "match": "(?:([a-zA-Z_][a-zA-Z0-9_\\-]*)|(\\((?:[^()]+|\\([^)]*\\))*\\))|(&&))",
+      "match": "(?x)\n  (?:\n    ([a-zA-Z_][a-zA-Z0-9_\\-]*)\n    | ( \\( \n        (?: [^\\(\\)]+ | \\( [^\\)]* \\))* \n      \\) )\n    | (&&)\n  )\n",
       "captures": {
         "1": {
           "name": "entity.name.function.just"
@@ -644,7 +627,7 @@
           "patterns": [
             {
               "comment": "Recipe with default values",
-              "match": "\\((?:([a-zA-Z_][a-zA-Z0-9_\\-]*)(.*))\\)",
+              "match": "(?x)\n  \\( \n    (?: \n      ([a-zA-Z_][a-zA-Z0-9_\\-]*)\n      (.*)\n    )\n  \\)\n",
               "captures": {
                 "1": {
                   "name": "entity.name.function.just"
@@ -665,39 +648,62 @@
         }
       }
     },
-    "recipes": {
+    "embedded-languages": {
       "patterns": [
         {
-          "include": "#recipe-attributes"
+          "comment": "JavaScript",
+          "begin": "^\\s+#!/usr/bin/env\\s+node.*$",
+          "end": "^$",
+          "contentName": "source.js",
+          "patterns": [
+            {
+              "include": "source.js"
+            }
+          ]
         },
         {
-          "comment": "Recipe definition",
-          "match": "^(@_|_@|@|_)?([a-zA-Z][a-zA-Z0-9_\\-]*)(?:\\s+(.*))?\\s*(:)(.*)",
-          "captures": {
-            "1": {
-              "name": "keyword.other.recipe.prefix.just"
-            },
-            "2": {
-              "name": "entity.name.function.just"
-            },
-            "3": {
-              "patterns": [
-                {
-                  "include": "#recipe-params"
-                }
-              ]
-            },
-            "4": {
-              "name": "keyword.operator.recipe.end.just"
-            },
-            "5": {
-              "patterns": [
-                {
-                  "include": "#recipe-dependencies"
-                }
-              ]
+          "comment": "Perl",
+          "begin": "^\\s+#!/usr/bin/env\\s+perl.*$",
+          "end": "^$",
+          "contentName": "source.perl",
+          "patterns": [
+            {
+              "include": "source.perl"
             }
-          }
+          ]
+        },
+        {
+          "comment": "Python",
+          "begin": "^\\s+#!/usr/bin/env\\s+python.*$",
+          "end": "^$",
+          "contentName": "source.python",
+          "patterns": [
+            {
+              "include": "source.python"
+            }
+          ]
+        },
+        {
+          "comment": "Ruby",
+          "begin": "^\\s+#!/usr/bin/env\\s+ruby.*$",
+          "end": "^$",
+          "contentName": "source.ruby",
+          "patterns": [
+            {
+              "include": "source.ruby"
+            }
+          ]
+        },
+        {
+          "comment": "Shell",
+          "begin": "^\\s+#!/usr/bin/env\\s+(sh|bash|zsh|fish).*$",
+          "end": "^$",
+          "contentName": "source.shell",
+          "patterns": [
+            {
+              "include": "source.shell"
+            }
+          ]
         }
       ]
     }

--- a/syntaxes/just.tmLanguage.json
+++ b/syntaxes/just.tmLanguage.json
@@ -363,7 +363,7 @@
         {
           "comment": "Non-escaped curly braces in string",
           "name": "string.quoted.double.indented.just",
-          "match": "([\"']{1,3})[\\{]+(\\1)"
+          "match": "([\\\"']{1,3})[\\{]+(\\1)"
         },
         {
           "comment": "Indented string",
@@ -456,9 +456,8 @@
     "escaping": {
       "patterns": [
         {
-          "comment": "Variable escaping",
           "name": "string.interpolated.escaping.just",
-          "match": "(?<!\\{)(\\{\\{)\\{?(?!\\{)(.*?)(\\}\\})",
+          "match": "(?x)\n  (?<!\\{)\n  (\\{\\{)\n    \\{? (?!\\{)\n    (.*?)\n  (\\}\\})\n",
           "captures": {
             "1": {
               "name": "string.interpolated.escape.just"

--- a/syntaxes/just.tmLanguage.json
+++ b/syntaxes/just.tmLanguage.json
@@ -109,7 +109,7 @@
           "name": "keyword.other.reserved.just"
         },
         "2": {
-          "name": "variable.other.just"
+          "name": "variable.name.alias.just"
         },
         "3": {
           "name": "keyword.operator.assignment.just"

--- a/syntaxes/just.tmLanguage.json
+++ b/syntaxes/just.tmLanguage.json
@@ -50,7 +50,7 @@
       "include": "#recipes"
     },
     {
-      "include": "#parenthesis-block"
+      "include": "#parenthesis"
     }
   ],
   "repository": {
@@ -174,6 +174,28 @@
         }
       ]
     },
+    "expression": {
+      "patterns": [
+        {
+          "include": "#backtick"
+        },
+        {
+          "include": "#builtins"
+        },
+        {
+          "include": "#control-keywords"
+        },
+        {
+          "include": "#operators"
+        },
+        {
+          "include": "#parenthesis"
+        },
+        {
+          "include": "#strings"
+        }
+      ]
+    },
     "builtins": {
       "patterns": [
         {
@@ -229,17 +251,42 @@
     "keywords": {
       "patterns": [
         {
+          "include": "#reserved-keywords"
+        },
+        {
+          "include": "#control-keywords"
+        }
+      ]
+    },
+    "reserved-keywords": {
+      "patterns": [
+        {
           "match": "^(alias|export|import|mod|set)\\s+",
           "captures": {
             "1": {
               "name": "keyword.other.reserved.just"
             }
           }
-        },
+        }
+      ]
+    },
+    "control-keywords": {
+      "patterns": [
         {
-          "comment": "Conditional",
           "name": "keyword.control.conditional.just",
           "match": "\\b(if|else)\\b"
+        }
+      ]
+    },
+    "parenthesis": {
+      "begin": "\\(",
+      "end": "\\)",
+      "patterns": [
+        {
+          "include": "#expression"
+        },
+        {
+          "include": "#parenthesis"
         }
       ]
     },
@@ -497,19 +544,7 @@
             "2": {
               "patterns": [
                 {
-                  "include": "#keywords"
-                },
-                {
-                  "include": "#operators"
-                },
-                {
-                  "include": "#builtins"
-                },
-                {
-                  "include": "#backtick"
-                },
-                {
-                  "include": "#strings"
+                  "include": "#expression"
                 }
               ]
             },
@@ -592,7 +627,7 @@
         "6": {
           "patterns": [
             {
-              "include": "#parenthesis-block"
+              "include": "#parenthesis"
             }
           ]
         }
@@ -617,19 +652,7 @@
                 "2": {
                   "patterns": [
                     {
-                      "include": "#builtin-functions"
-                    },
-                    {
-                      "include": "#backtick"
-                    },
-                    {
-                      "include": "#keywords"
-                    },
-                    {
-                      "include": "#operators"
-                    },
-                    {
-                      "include": "#strings"
+                      "include": "#expression"
                     }
                   ]
                 }
@@ -675,34 +698,6 @@
               ]
             }
           }
-        }
-      ]
-    },
-    "expression": {
-      "patterns": [
-        {
-          "include": "#builtins"
-        },
-        {
-          "include": "#keywords"
-        },
-        {
-          "include": "#operators"
-        },
-        {
-          "include": "#backtick"
-        },
-        {
-          "include": "#strings"
-        }
-      ]
-    },
-    "parenthesis-block": {
-      "begin": "\\(",
-      "end": "\\)",
-      "patterns": [
-        {
-          "include": "#expression"
         }
       ]
     }

--- a/syntaxes/just.tmLanguage.json
+++ b/syntaxes/just.tmLanguage.json
@@ -2,11 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "Just",
   "scopeName": "source.just",
-  "fileTypes": [
-    "just",
-    "justfile",
-    "Justfile"
-  ],
+  "fileTypes": ["just", "justfile", "Justfile"],
   "firstLineMatch": "#![\\s\\t]*\\/.*\\just\\b",
   "uuid": "8b0cfae0-229f-4688-a4b7-8b5c3db82855",
   "patterns": [

--- a/syntaxes/just.tmLanguage.json
+++ b/syntaxes/just.tmLanguage.json
@@ -55,19 +55,41 @@
     "constants": {
       "patterns": [
         {
-          "comment": "Boolean",
-          "name": "constant.language.boolean.just",
-          "match": "\\b(true|false)\\b"
-        },
-        {
-          "comment": "Integer",
-          "name": "constant.language.integer.just",
-          "match": "\\b\\d+\\b"
-        },
-        {
-          "comment": "Hex",
           "name": "constant.language.hex.just",
           "match": "\\b(HEX|HEXLOWER|HEXUPPER)\\b"
+        },
+        {
+          "include": "#literal"
+        }
+      ]
+    },
+    "literal": {
+      "patterns": [
+        {
+          "include": "#boolean"
+        },
+        {
+          "include": "#number"
+        }
+      ]
+    },
+    "boolean": {
+      "patterns": [
+        {
+          "name": "constant.language.boolean.just",
+          "match": "\\b(true|false)\\b"
+        }
+      ]
+    },
+    "number": {
+      "patterns": [
+        {
+          "name": "constant.numeric.just",
+          "match": "(?x)\n  (?<! [a-zA-Z_\\-])(?:\n    \\. \\d+\n    |\n    \\d+ \\. \\d+\n    |\n    \\d+ \\.\n    |\n    [1-9] \\d*\n  )\n"
+        },
+        {
+          "name": "invalid.illegal.name.just",
+          "match": "\\b[0-9]+[a-zA-Z_\\-]+\\b"
         }
       ]
     },
@@ -543,7 +565,7 @@
           "include": "#recipe-attributes"
         },
         {
-          "comment": "Recipe defintition",
+          "comment": "Recipe definition",
           "match": "^(@_|_@|@|_)?([a-zA-Z][a-zA-Z0-9_\\-]*)(?:\\s+(.*))?\\s*(:)(.*)",
           "captures": {
             "1": {

--- a/syntaxes/just.tmLanguage.yml
+++ b/syntaxes/just.tmLanguage.yml
@@ -255,7 +255,7 @@ repository:
     patterns:
       - comment: Non-escaped curly braces in string
         name: string.quoted.double.indented.just
-        match: "([\"']{1,3})[\\{]+(\\1)"
+        match: ([\"']{1,3})[\{]+(\1)
       - comment: Indented string
         name: string.quoted.double.indented.just
         begin: '(x)?(""")'
@@ -309,9 +309,14 @@ repository:
 
   escaping:
     patterns:
-      - comment: Variable escaping
-        name: string.interpolated.escaping.just
-        match: "(?<!\\{)(\\{\\{)\\{?(?!\\{)(.*?)(\\}\\})"
+      - name: string.interpolated.escaping.just
+        match: |
+          (?x)
+            (?<!\{)
+            (\{\{)
+              \{? (?!\{)
+              (.*?)
+            (\}\})
         captures:
           '1':
             name: string.interpolated.escape.just

--- a/syntaxes/just.tmLanguage.yml
+++ b/syntaxes/just.tmLanguage.yml
@@ -22,7 +22,6 @@ patterns:
   - include: '#embedded-languages'
   - include: '#escaping'
 
-
 repository:
   comments:
     patterns:
@@ -104,7 +103,7 @@ repository:
             name: keyword.operator.assignment.just
         patterns:
           - include: '#expression'
-      
+
   setting-assignment:
     patterns:
       - begin: |
@@ -139,7 +138,7 @@ repository:
     patterns:
       - name: constant.language.hex.just
         match: \b(HEX|HEXLOWER|HEXUPPER)\b
-      - include: "#builtin-functions"
+      - include: '#builtin-functions'
       - include: '#literal'
 
   builtin-functions:

--- a/syntaxes/just.tmLanguage.yml
+++ b/syntaxes/just.tmLanguage.yml
@@ -39,7 +39,7 @@ repository:
       '1':
         name: keyword.other.reserved.just
       '2':
-        name: keyword.operator.optional.just
+        name: punctuation.optional.just
     patterns:
       - include: '#strings'
 
@@ -56,7 +56,7 @@ repository:
       '1':
         name: keyword.other.reserved.just
       '2':
-        name: keyword.operator.optional.just
+        name: punctuation.optional.just
       '3':
         name: variable.name.module.just
     patterns:

--- a/syntaxes/just.tmLanguage.yml
+++ b/syntaxes/just.tmLanguage.yml
@@ -6,11 +6,11 @@ firstLineMatch: "#![\\s\\t]*\\/.*\\just\\b"
 uuid: 8b0cfae0-229f-4688-a4b7-8b5c3db82855
 
 patterns:
-  - include: '#assignment'
   - include: '#comments'
   - include: '#import'
   - include: '#module'
   - include: '#alias'
+  - include: '#assignment'
   - include: '#builtins'
   - include: '#keywords'
   - include: '#operators'
@@ -79,6 +79,50 @@ repository:
       '4':
         name: variable.other.just
 
+  assignment:
+    patterns:
+      - include: '#variable-assignment'
+      - include: '#setting-assignment'
+
+  variable-assignment:
+    patterns:
+      - begin: |
+          (?x) 
+            ^
+            (?: (export) \s+)?
+            ([a-zA-Z_][a-zA-Z0-9_-]*) \s*
+            (:=)
+        end: $
+        beginCaptures:
+          '1':
+            name: keyword.other.reserved.just
+          '2':
+            name: variable.other.just
+          '3':
+            name: keyword.operator.assignment.just
+        patterns:
+          - include: '#expression'
+      
+  setting-assignment:
+    patterns:
+      - begin: |
+          (?x) 
+            ^
+            (set) \s+
+            ([a-zA-Z_][a-zA-Z0-9_-]*) \s*
+            (:=)?
+        end: $
+        beginCaptures:
+          '1':
+            name: keyword.other.reserved.just
+          '2':
+            name: variable.other.just
+          '3':
+            name: keyword.operator.assignment.just
+        patterns:
+          # Allow any expression here for simplicity right now
+          - include: '#expression'
+
   builtins:
     patterns:
       - name: constant.language.hex.just
@@ -136,8 +180,7 @@ repository:
 
   keywords:
     patterns:
-      - comment: Reserved
-        match: "^(alias|export|import|mod|set)\\s+"
+      - match: "^(alias|export|import|mod|set)\\s+"
         captures:
           '1':
             name: keyword.other.reserved.just
@@ -171,27 +214,6 @@ repository:
         captures:
           '1':
             name: keyword.operator.error-suppression.just
-
-  assignment:
-    patterns:
-      - comment: Variable
-        match: "^(?:(export)\\s+)?([a-zA-Z_][a-zA-Z0-9_-]*)\\s*(:=)"
-        captures:
-          '1':
-            name: keyword.other.assignment.just
-          '2':
-            name: variable.other.just
-          '3':
-            name: keyword.operator.assignment.just
-      - comment: Setting
-        match: "^(set)\\s+([a-zA-Z_][a-zA-Z0-9_-]*)\\s*(:=)?"
-        captures:
-          '1':
-            name: keyword.other.reserved.just
-          '2':
-            name: variable.language.setting.just
-          '3':
-            name: keyword.operator.assignment.just
 
   backtick:
     patterns:

--- a/syntaxes/just.tmLanguage.yml
+++ b/syntaxes/just.tmLanguage.yml
@@ -74,7 +74,7 @@ repository:
       '1':
         name: keyword.other.reserved.just
       '2':
-        name: variable.other.just
+        name: variable.name.alias.just
       '3':
         name: keyword.operator.assignment.just
       '4':

--- a/syntaxes/just.tmLanguage.yml
+++ b/syntaxes/just.tmLanguage.yml
@@ -11,10 +11,9 @@ patterns:
   - include: '#import'
   - include: '#module'
   - include: '#alias'
-  - include: '#constants'
+  - include: '#builtins'
   - include: '#keywords'
   - include: '#operators'
-  - include: '#builtins'
   - include: '#backtick'
   - include: '#embedded-languages'
   - include: '#strings'
@@ -80,11 +79,33 @@ repository:
       '4':
         name: variable.other.just
 
-  constants:
+  builtins:
     patterns:
       - name: constant.language.hex.just
-        match: "\\b(HEX|HEXLOWER|HEXUPPER)\\b"
+        match: \b(HEX|HEXLOWER|HEXUPPER)\b
+      - include: "#builtin-functions"
       - include: '#literal'
+
+  builtin-functions:
+    patterns:
+      - name: support.function.builtin.just
+        match: |
+          (?x) \b(
+            arch|num_cpus|os|os_family|shell|env_var|env_var_or_default|env|
+            is_dependency|invocation_directory|invocation_directory_native|
+            justfile|justfile_directory|just_executable|just_pid|source_file|
+            source_directory|module_file|module_directory|append|prepend|
+            encode_uri_component|quote|replace|replace_regex|trim|trim_end|
+            trim_end_match|trim_end_matches|trim_start|trim_start_match|
+            trim_start_matches|capitalize|kebabcase|lowercamelcase|lowercase|
+            shoutykebabcase|shoutysnakecase|snakecase|titlecase|uppercamelcase|
+            uppercase|absolute_path|blake3|blake3_file|canonicalize|extension|
+            file_name|file_stem|parent_directory|without_extension|clean|join|
+            path_exists|error|assert|sha256|sha256_file|uuid|choose|datetime|
+            datetime_utc|semver_matches|cache_directory|config_directory|
+            config_local_directory|data_directory|data_local_directory|
+            executable_directory|home_directory
+          )\b
 
   literal:
     patterns:
@@ -150,12 +171,6 @@ repository:
         captures:
           '1':
             name: keyword.operator.error-suppression.just
-
-  builtins:
-    patterns:
-      - commment: Functions
-        name: support.function.builtin.just
-        match: "\\b(arch|num_cpus|os|os_family|shell|env_var|env_var_or_default|env|is_dependency|invocation_directory|invocation_directory_native|justfile|justfile_directory|just_executable|just_pid|source_file|source_directory|module_file|module_directory|append|prepend|encode_uri_component|quote|replace|replace_regex|trim|trim_end|trim_end_match|trim_end_matches|trim_start|trim_start_match|trim_start_matches|capitalize|kebabcase|lowercamelcase|lowercase|shoutykebabcase|shoutysnakecase|snakecase|titlecase|uppercamelcase|uppercase|absolute_path|blake3|blake3_file|canonicalize|extension|file_name|file_stem|parent_directory|without_extension|clean|join|path_exists|error|assert|sha256|sha256_file|uuid|choose|datetime|datetime_utc|semver_matches|cache_directory|config_directory|config_local_directory|data_directory|data_local_directory|executable_directory|home_directory)\\b"
 
   assignment:
     patterns:
@@ -303,7 +318,6 @@ repository:
             name: string.interpolated.escape.just
           '2':
             patterns:
-              - include: '#constants'
               - include: '#keywords'
               - include: '#operators'
               - include: '#builtins'
@@ -371,7 +385,6 @@ repository:
               '2':
                 patterns:
                   - include: '#builtin-functions'
-                  - include: '#constants'
                   - include: '#backtick'
                   - include: '#keywords'
                   - include: '#operators'
@@ -401,7 +414,6 @@ repository:
   expression:
     patterns:
       - include: '#builtins'
-      - include: '#constants'
       - include: '#keywords'
       - include: '#operators'
       - include: '#backtick'

--- a/syntaxes/just.tmLanguage.yml
+++ b/syntaxes/just.tmLanguage.yml
@@ -8,6 +8,7 @@ uuid: 8b0cfae0-229f-4688-a4b7-8b5c3db82855
 patterns:
   - include: '#assignment'
   - include: '#comments'
+  - include: '#alias'
   - include: '#constants'
   - include: '#keywords'
   - include: '#operators'
@@ -24,6 +25,25 @@ repository:
     patterns:
       - name: comment.line.number-sign.just
         match: '#([^!].*)$'
+
+  alias:
+    match: |
+      (?x)
+        ^
+        (alias) \s+ 
+        ([a-zA-Z_][a-zA-Z0-9_-]*) \s* 
+        (:=) \s* 
+        ([a-zA-Z_][a-zA-Z0-9_-]*)
+    captures:
+      '1':
+        name: keyword.other.reserved.just
+      '2':
+        name: variable.other.just
+      '3':
+        name: keyword.operator.assignment.just
+      '4':
+        name: variable.other.just
+
 
   constants:
     patterns:
@@ -105,7 +125,7 @@ repository:
   assignment:
     patterns:
       - comment: Variable
-        match: "^(?:(alias|export)\\s+)?([a-zA-Z_][a-zA-Z0-9_-]*)\\s*(:=)"
+        match: "^(?:(export)\\s+)?([a-zA-Z_][a-zA-Z0-9_-]*)\\s*(:=)"
         captures:
           '1':
             name: keyword.other.assignment.just
@@ -344,14 +364,12 @@ repository:
               - include: '#recipe-dependencies'
 
   parenthesis-block:
-    comment: Any block of just code surrounded by (...)
-    match: "\\((.*?)\\)"
-    captures:
-      '1':
-        patterns:
-          - include: '#builtins'
-          - include: '#constants'
-          - include: '#keywords'
-          - include: '#operators'
-          - include: '#backtick'
-          - include: '#strings'
+    begin: \(
+    end: \)
+    patterns:
+      - include: '#builtins'
+      - include: '#constants'
+      - include: '#keywords'
+      - include: '#operators'
+      - include: '#backtick'
+      - include: '#strings'

--- a/syntaxes/just.tmLanguage.yml
+++ b/syntaxes/just.tmLanguage.yml
@@ -27,15 +27,36 @@ repository:
 
   constants:
     patterns:
-      - comment: Boolean
-        name: constant.language.boolean.just
-        match: "\\b(true|false)\\b"
-      - comment: Integer
-        name: constant.language.integer.just
-        match: "\\b\\d+\\b"
-      - comment: Hex
-        name: constant.language.hex.just
+      - name: constant.language.hex.just
         match: "\\b(HEX|HEXLOWER|HEXUPPER)\\b"
+      - include: '#literal'
+
+  literal:
+    patterns:
+      - include: '#boolean'
+      - include: '#number'
+
+  boolean:
+    patterns:
+      - name: constant.language.boolean.just
+        match: \b(true|false)\b
+
+  number:
+    patterns:
+      - name: constant.numeric.just
+        match: |
+          (?x)
+            (?<! [a-zA-Z_\-])(?:
+              \. \d+
+              |
+              \d+ \. \d+
+              |
+              \d+ \.
+              |
+              [1-9] \d*
+            )
+      - name: invalid.illegal.name.just
+        match: \b[0-9]+[a-zA-Z_\-]+\b
 
   keywords:
     patterns:
@@ -306,7 +327,7 @@ repository:
   recipes:
     patterns:
       - include: '#recipe-attributes'
-      - comment: Recipe defintition
+      - comment: Recipe definition
         match: "^(@_|_@|@|_)?([a-zA-Z][a-zA-Z0-9_\\-]*)(?:\\s+(.*))?\\s*(:)(.*)"
         captures:
           '1':

--- a/syntaxes/just.tmLanguage.yml
+++ b/syntaxes/just.tmLanguage.yml
@@ -19,7 +19,7 @@ patterns:
   - include: '#strings'
   - include: '#escaping'
   - include: '#recipes'
-  - include: '#parenthesis-block'
+  - include: '#parenthesis'
 
 repository:
   comments:
@@ -123,6 +123,16 @@ repository:
           # Allow any expression here for simplicity right now
           - include: '#expression'
 
+  expression:
+    patterns:
+      - include: '#backtick'
+      - include: '#builtins'
+      - include: '#control-keywords'
+      - include: '#operators'
+      - include: '#parenthesis'
+      - include: '#strings'
+      # - include: '#expression'
+
   builtins:
     patterns:
       - name: constant.language.hex.just
@@ -180,13 +190,27 @@ repository:
 
   keywords:
     patterns:
+      - include: '#reserved-keywords'
+      - include: '#control-keywords'
+
+  reserved-keywords:
+    patterns:
       - match: "^(alias|export|import|mod|set)\\s+"
         captures:
           '1':
             name: keyword.other.reserved.just
-      - comment: Conditional
-        name: keyword.control.conditional.just
+
+  control-keywords:
+    patterns:
+      - name: keyword.control.conditional.just
         match: "\\b(if|else)\\b"
+
+  parenthesis:
+    begin: \(
+    end: \)
+    patterns:
+      - include: '#expression'
+      - include: '#parenthesis'
 
   operators:
     patterns:
@@ -340,11 +364,7 @@ repository:
             name: string.interpolated.escape.just
           '2':
             patterns:
-              - include: '#keywords'
-              - include: '#operators'
-              - include: '#builtins'
-              - include: '#backtick'
-              - include: '#strings'
+              - include: '#expression'
           '3':
             name: string.interpolated.escape.just
 
@@ -389,7 +409,7 @@ repository:
           - include: '#backtick'
       '6':
         patterns:
-          - include: '#parenthesis-block'
+          - include: '#parenthesis'
 
   recipe-dependencies:
     comment: Recipe dependencies
@@ -406,11 +426,7 @@ repository:
                 name: entity.name.function.just
               '2':
                 patterns:
-                  - include: '#builtin-functions'
-                  - include: '#backtick'
-                  - include: '#keywords'
-                  - include: '#operators'
-                  - include: '#strings'
+                  - include: '#expression'
       '3':
         name: keyword.operator.and.just
 
@@ -433,16 +449,3 @@ repository:
             patterns:
               - include: '#recipe-dependencies'
 
-  expression:
-    patterns:
-      - include: '#builtins'
-      - include: '#keywords'
-      - include: '#operators'
-      - include: '#backtick'
-      - include: '#strings'
-
-  parenthesis-block:
-    begin: \(
-    end: \)
-    patterns:
-      - include: '#expression'

--- a/syntaxes/just.tmLanguage.yml
+++ b/syntaxes/just.tmLanguage.yml
@@ -13,13 +13,15 @@ patterns:
   - include: '#assignment'
   - include: '#builtins'
   - include: '#keywords'
-  - include: '#operators'
+  - include: '#expression-operators'
   - include: '#backtick'
-  - include: '#embedded-languages'
   - include: '#strings'
-  - include: '#escaping'
-  - include: '#recipes'
   - include: '#parenthesis'
+  - include: '#recipes'
+  - include: '#recipe-operators'
+  - include: '#embedded-languages'
+  - include: '#escaping'
+
 
 repository:
   comments:
@@ -128,7 +130,7 @@ repository:
       - include: '#backtick'
       - include: '#builtins'
       - include: '#control-keywords'
-      - include: '#operators'
+      - include: '#expression-operators'
       - include: '#parenthesis'
       - include: '#strings'
       # - include: '#expression'
@@ -212,32 +214,16 @@ repository:
       - include: '#expression'
       - include: '#parenthesis'
 
-  operators:
+  expression-operators:
     patterns:
-      # General
-      - comment: Path join
-        name: keyword.operator.path-join.just
+      - name: keyword.operator.path-join.just
         match: "\\/"
-      - comment: Concatenation
-        name: keyword.operator.concat.just
+      - name: keyword.operator.concat.just
         match: "\\+"
-      - comment: And
-        name: keyword.operator.and.just
+      - name: keyword.operator.and.just
         match: '&&'
-      - comment: Equality
-        name: keyword.operator.equality.just
+      - name: keyword.operator.equality.just
         match: "(\\=\\=|\\=\\~|\\!\\=)"
-      # Recipes
-      - comment: Quiet
-        match: "^\\s+(@)"
-        captures:
-          '1':
-            name: keyword.operator.quiet.just
-      - comment: Error suppression
-        match: "^\\s+(\\-)"
-        captures:
-          '1':
-            name: keyword.operator.error-suppression.just
 
   backtick:
     patterns:
@@ -264,39 +250,6 @@ repository:
               - include: source.shell
           '3':
             name: string.interpolated.just
-
-  embedded-languages:
-    patterns:
-      - comment: JavaScript
-        begin: "^\\s+#!/usr/bin/env\\s+node.*$"
-        end: ^$
-        contentName: source.js
-        patterns:
-          - include: source.js
-      - comment: Perl
-        begin: "^\\s+#!/usr/bin/env\\s+perl.*$"
-        end: ^$
-        contentName: source.perl
-        patterns:
-          - include: source.perl
-      - comment: Python
-        begin: "^\\s+#!/usr/bin/env\\s+python.*$"
-        end: ^$
-        contentName: source.python
-        patterns:
-          - include: source.python
-      - comment: Ruby
-        begin: "^\\s+#!/usr/bin/env\\s+ruby.*$"
-        end: ^$
-        contentName: source.ruby
-        patterns:
-          - include: source.ruby
-      - comment: Shell
-        begin: "^\\s+#!/usr/bin/env\\s+(sh|bash|zsh|fish).*$"
-        end: ^$
-        contentName: source.shell
-        patterns:
-          - include: source.shell
 
   strings:
     patterns:
@@ -368,17 +321,71 @@ repository:
           '3':
             name: string.interpolated.escape.just
 
+  recipes:
+    patterns:
+      - match: |
+          (?x)
+            ^
+            (@_|_@|@|_)?
+            ([a-zA-Z][a-zA-Z0-9_\-]*)
+            (?: \s+ (.*?) )?
+            \s* (:)
+            (.*)
+        captures:
+          '1':
+            name: keyword.other.recipe.prefix.just
+          '2':
+            name: entity.name.function.just
+          '3':
+            patterns:
+              - include: '#recipe-params'
+          '4':
+            name: keyword.operator.recipe.end.just
+          '5':
+            patterns:
+              - include: '#recipe-dependencies'
+      - include: '#recipe-operators'
+      - include: '#recipe-attributes'
+      - include: '#embedded-languages'
+
+  recipe-operators:
+    patterns:
+      - match: "^\\s+(@)"
+        captures:
+          '1':
+            name: keyword.operator.quiet.just
+      - match: "^\\s+(\\-)"
+        captures:
+          '1':
+            name: keyword.operator.error-suppression.just
+
   recipe-attributes:
     patterns:
       - comment: Multiple recipe attributes
-        match: "^\\[([a-zA-z\\-]+)\\s*(?:,(\\s*[a-zA-z\\-]+\\s*))*]\\s*$"
+        match: |
+          (?x)
+            ^
+            \[ 
+              ([a-zA-z\-]+) \s*
+              (?: , ( \s* [a-zA-z\-]+ \s* ) )*
+            ] \s*
+            $
         captures:
           '1':
             name: support.function.system.just
           '2':
             name: support.function.system.just
       - comment: Recipe attribute with value
-        match: "^\\[([a-zA-z\\-]+)(?:(?:(:)(.*?))|(\\((.*?)\\)))?]\\s*$"
+        match: |
+          (?x)
+            ^
+            \[
+              ([a-zA-z\-]+)
+              (?: 
+                (?: (:) (.*?) ) | (\( (.*?) \))
+              )?
+            ] \s*
+            $
         captures:
           '1':
             name: support.function.system.just
@@ -393,7 +400,26 @@ repository:
 
   recipe-params:
     comment: Recipe parameters
-    match: "(?:(\\+|\\*|\\$)?([a-zA-Z_][a-zA-Z_0-9]*)(?:(=)(?:[a-zA-Z_][a-zA-Z_0-9]*|(\".*?\"|'.*?')|(`.*?`)|(\\((?:[^()]+|\\([^)]*\\))*\\))))?)"
+    match: |
+      (?x)
+        (?: 
+          (\+|\*|\$)?
+          ([a-zA-Z_][a-zA-Z_0-9]*
+        )
+        (?:
+          (=)
+          (?: 
+            [a-zA-Z_][a-zA-Z_0-9]* 
+            | (\".*?\" | '.*?') 
+            | (`.*?`) 
+            | ( \( 
+                (?: 
+                  [^\(\)]+ 
+                  | \( [^)]* \)
+                )* \) ) 
+              ) 
+          )?
+        )
     captures:
       '1':
         name: keyword.other.recipe.variadic.just
@@ -413,14 +439,29 @@ repository:
 
   recipe-dependencies:
     comment: Recipe dependencies
-    match: "(?:([a-zA-Z_][a-zA-Z0-9_\\-]*)|(\\((?:[^()]+|\\([^)]*\\))*\\))|(&&))"
+    match: |
+      (?x)
+        (?:
+          ([a-zA-Z_][a-zA-Z0-9_\-]*)
+          | ( \( 
+              (?: [^\(\)]+ | \( [^\)]* \))* 
+            \) )
+          | (&&)
+        )
     captures:
       '1':
         name: entity.name.function.just
       '2':
         patterns:
           - comment: Recipe with default values
-            match: "\\((?:([a-zA-Z_][a-zA-Z0-9_\\-]*)(.*))\\)"
+            match: |
+              (?x)
+                \( 
+                  (?: 
+                    ([a-zA-Z_][a-zA-Z0-9_\-]*)
+                    (.*)
+                  )
+                \)
             captures:
               '1':
                 name: entity.name.function.just
@@ -430,22 +471,35 @@ repository:
       '3':
         name: keyword.operator.and.just
 
-  recipes:
+  embedded-languages:
     patterns:
-      - include: '#recipe-attributes'
-      - comment: Recipe definition
-        match: "^(@_|_@|@|_)?([a-zA-Z][a-zA-Z0-9_\\-]*)(?:\\s+(.*))?\\s*(:)(.*)"
-        captures:
-          '1':
-            name: keyword.other.recipe.prefix.just
-          '2':
-            name: entity.name.function.just
-          '3':
-            patterns:
-              - include: '#recipe-params'
-          '4':
-            name: keyword.operator.recipe.end.just
-          '5':
-            patterns:
-              - include: '#recipe-dependencies'
-
+      - comment: JavaScript
+        begin: "^\\s+#!/usr/bin/env\\s+node.*$"
+        end: ^$
+        contentName: source.js
+        patterns:
+          - include: source.js
+      - comment: Perl
+        begin: "^\\s+#!/usr/bin/env\\s+perl.*$"
+        end: ^$
+        contentName: source.perl
+        patterns:
+          - include: source.perl
+      - comment: Python
+        begin: "^\\s+#!/usr/bin/env\\s+python.*$"
+        end: ^$
+        contentName: source.python
+        patterns:
+          - include: source.python
+      - comment: Ruby
+        begin: "^\\s+#!/usr/bin/env\\s+ruby.*$"
+        end: ^$
+        contentName: source.ruby
+        patterns:
+          - include: source.ruby
+      - comment: Shell
+        begin: "^\\s+#!/usr/bin/env\\s+(sh|bash|zsh|fish).*$"
+        end: ^$
+        contentName: source.shell
+        patterns:
+          - include: source.shell

--- a/syntaxes/just.tmLanguage.yml
+++ b/syntaxes/just.tmLanguage.yml
@@ -350,7 +350,7 @@ repository:
           - include: '#strings'
       '5':
         patterns:
-          - include: '#inline-shell'
+          - include: '#backtick'
       '6':
         patterns:
           - include: '#parenthesis-block'
@@ -372,7 +372,7 @@ repository:
                 patterns:
                   - include: '#builtin-functions'
                   - include: '#constants'
-                  - include: '#inline-shell'
+                  - include: '#backtick'
                   - include: '#keywords'
                   - include: '#operators'
                   - include: '#strings'
@@ -398,9 +398,7 @@ repository:
             patterns:
               - include: '#recipe-dependencies'
 
-  parenthesis-block:
-    begin: \(
-    end: \)
+  expression:
     patterns:
       - include: '#builtins'
       - include: '#constants'
@@ -408,3 +406,9 @@ repository:
       - include: '#operators'
       - include: '#backtick'
       - include: '#strings'
+
+  parenthesis-block:
+    begin: \(
+    end: \)
+    patterns:
+      - include: '#expression'

--- a/syntaxes/just.tmLanguage.yml
+++ b/syntaxes/just.tmLanguage.yml
@@ -8,6 +8,8 @@ uuid: 8b0cfae0-229f-4688-a4b7-8b5c3db82855
 patterns:
   - include: '#assignment'
   - include: '#comments'
+  - include: '#import'
+  - include: '#module'
   - include: '#alias'
   - include: '#constants'
   - include: '#keywords'
@@ -26,6 +28,40 @@ repository:
       - name: comment.line.number-sign.just
         match: '#([^!].*)$'
 
+  import:
+    begin: |
+      (?x)
+        ^
+        (import)
+        (\?)? \s+
+    end: $
+    beginCaptures:
+      '1':
+        name: keyword.other.reserved.just
+      '2':
+        name: keyword.operator.optional.just
+    patterns:
+      - include: '#strings'
+
+  module:
+    begin: |
+      (?x)
+        ^
+        (mod)
+        (\?)? \s+
+        ([a-zA-Z_][a-zA-Z0-9_-]*)
+        (?=[$\s])
+    end: $
+    beginCaptures:
+      '1':
+        name: keyword.other.reserved.just
+      '2':
+        name: keyword.operator.optional.just
+      '3':
+        name: variable.name.module.just
+    patterns:
+      - include: '#strings'
+
   alias:
     match: |
       (?x)
@@ -43,7 +79,6 @@ repository:
         name: keyword.operator.assignment.just
       '4':
         name: variable.other.just
-
 
   constants:
     patterns:

--- a/tests/embedded/command_evaluation.just.snap
+++ b/tests/embedded/command_evaluation.just.snap
@@ -17,7 +17,7 @@
 #        ^ source.just
 #         ^ source.just string.interpolated.just
 #          ^ source.just string.interpolated.just
-#           ^^ source.just
+#           ^ source.just
 >    echo foo
 #^^^^^^^^^^^^^ source.just
 >    echo bar

--- a/tests/general/builtins.just
+++ b/tests/general/builtins.just
@@ -13,8 +13,6 @@ else
 
 # Builtin functions
 
-# TODO: should parentheses be optional or required?
-
 # System info
 
 arch()

--- a/tests/general/builtins.just
+++ b/tests/general/builtins.just
@@ -1,4 +1,4 @@
-# Builin keywords
+# Reserved keywords
 
 alias
 set

--- a/tests/general/builtins.just.snap
+++ b/tests/general/builtins.just.snap
@@ -23,9 +23,6 @@
 ># Builtin functions
 #^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
 >
-># TODO: should parentheses be optional or required?
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
->
 ># System info
 #^^^^^^^^^^^^^ source.just comment.line.number-sign.just
 >

--- a/tests/general/builtins.just.snap
+++ b/tests/general/builtins.just.snap
@@ -31,16 +31,20 @@
 >
 >arch()
 #^^^^ source.just support.function.builtin.just
-#    ^^ source.just
+#    ^ source.just
+#     ^ source.just
 >num_cpus()
 #^^^^^^^^ source.just support.function.builtin.just
-#        ^^ source.just
+#        ^ source.just
+#         ^ source.just
 >os()
 #^^ source.just support.function.builtin.just
-#  ^^ source.just
+#  ^ source.just
+#   ^ source.just
 >os_family()
 #^^^^^^^^^ source.just support.function.builtin.just
-#         ^^ source.just
+#         ^ source.just
+#          ^ source.just
 >
 ># External commands
 #^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
@@ -80,46 +84,56 @@
 >
 >is_dependency()
 #^^^^^^^^^^^^^ source.just support.function.builtin.just
-#             ^^ source.just
+#             ^ source.just
+#              ^ source.just
 >
 ># Invocation directory
 #^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
 >
 >invocation_directory()
 #^^^^^^^^^^^^^^^^^^^^ source.just support.function.builtin.just
-#                    ^^ source.just
+#                    ^ source.just
+#                     ^ source.just
 >
 ># Just
 #^^^^^^ source.just comment.line.number-sign.just
 >
 >justfile()
 #^^^^^^^^ source.just support.function.builtin.just
-#        ^^ source.just
+#        ^ source.just
+#         ^ source.just
 >justfile_directory()
 #^^^^^^^^^^^^^^^^^^ source.just support.function.builtin.just
-#                  ^^ source.just
+#                  ^ source.just
+#                   ^ source.just
 >just_executable()
 #^^^^^^^^^^^^^^^ source.just support.function.builtin.just
-#               ^^ source.just
+#               ^ source.just
+#                ^ source.just
 >just_pid()
 #^^^^^^^^ source.just support.function.builtin.just
-#        ^^ source.just
+#        ^ source.just
+#         ^ source.just
 >
 ># Source
 #^^^^^^^^ source.just comment.line.number-sign.just
 >
 >source_file()
 #^^^^^^^^^^^ source.just support.function.builtin.just
-#           ^^ source.just
+#           ^ source.just
+#            ^ source.just
 >source_directory()
 #^^^^^^^^^^^^^^^^ source.just support.function.builtin.just
-#                ^^ source.just
+#                ^ source.just
+#                 ^ source.just
 >module_file()
 #^^^^^^^^^^^ source.just support.function.builtin.just
-#           ^^ source.just
+#           ^ source.just
+#            ^ source.just
 >module_directory()
 #^^^^^^^^^^^^^^^^ source.just support.function.builtin.just
-#                ^^ source.just
+#                ^ source.just
+#                 ^ source.just
 >
 >
 ># Strings
@@ -340,7 +354,8 @@
 #                ^ source.just
 >uuid()
 #^^^^ source.just support.function.builtin.just
-#    ^^ source.just
+#    ^ source.just
+#     ^ source.just
 >
 >choose(n, alphabet)
 #^^^^^^ source.just support.function.builtin.just
@@ -367,23 +382,30 @@
 >
 >cache_directory()
 #^^^^^^^^^^^^^^^ source.just support.function.builtin.just
-#               ^^ source.just
+#               ^ source.just
+#                ^ source.just
 >config_directory()
 #^^^^^^^^^^^^^^^^ source.just support.function.builtin.just
-#                ^^ source.just
+#                ^ source.just
+#                 ^ source.just
 >config_local_directory()
 #^^^^^^^^^^^^^^^^^^^^^^ source.just support.function.builtin.just
-#                      ^^ source.just
+#                      ^ source.just
+#                       ^ source.just
 >data_directory()
 #^^^^^^^^^^^^^^ source.just support.function.builtin.just
-#              ^^ source.just
+#              ^ source.just
+#               ^ source.just
 >data_local_directory()
 #^^^^^^^^^^^^^^^^^^^^ source.just support.function.builtin.just
-#                    ^^ source.just
+#                    ^ source.just
+#                     ^ source.just
 >executable_directory()
 #^^^^^^^^^^^^^^^^^^^^ source.just support.function.builtin.just
-#                    ^^ source.just
+#                    ^ source.just
+#                     ^ source.just
 >home_directory()
 #^^^^^^^^^^^^^^ source.just support.function.builtin.just
-#              ^^ source.just
+#              ^ source.just
+#               ^ source.just
 >

--- a/tests/general/builtins.just.snap
+++ b/tests/general/builtins.just.snap
@@ -1,5 +1,5 @@
-># Builin keywords
-#^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
+># Reserved keywords
+#^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
 >
 >alias
 #^^^^^ source.just keyword.other.reserved.just

--- a/tests/general/constants.just
+++ b/tests/general/constants.just
@@ -3,6 +3,12 @@
 true
 false
 
+1234
+1234.
+12.34
+0.1234
+.1234
+
 HEX
 HEXLOWER
 HEXUPPER

--- a/tests/general/constants.just.snap
+++ b/tests/general/constants.just.snap
@@ -6,6 +6,17 @@
 >false
 #^^^^^ source.just constant.language.boolean.just
 >
+>1234
+#^^^^ source.just constant.numeric.just
+>1234.
+#^^^^^ source.just constant.numeric.just
+>12.34
+#^^^^^ source.just constant.numeric.just
+>0.1234
+#^^^^^^ source.just constant.numeric.just
+>.1234
+#^^^^^ source.just constant.numeric.just
+>
 >HEX
 #^^^ source.just constant.language.hex.just
 >HEXLOWER

--- a/tests/general/general.just
+++ b/tests/general/general.just
@@ -7,5 +7,8 @@ something # Comment after code
 # Imports
 
 import 'foo/bar.just'
+import? 'foo/bar.just'
 
 mod bar
+mod? bar
+mode bar 'foo/bar.just'

--- a/tests/general/general.just
+++ b/tests/general/general.just
@@ -4,12 +4,6 @@
 
 something # Comment after code
 
-# Numbers
-
-123
-# TODO: should the "." be colored differently?
-123.456
-
 # Imports
 
 import 'foo/bar.just'

--- a/tests/general/general.just
+++ b/tests/general/general.just
@@ -11,4 +11,4 @@ import? 'foo/bar.just'
 
 mod bar
 mod? bar
-mode bar 'foo/bar.just'
+mod bar 'foo/bar.just'

--- a/tests/general/general.just.snap
+++ b/tests/general/general.just.snap
@@ -17,9 +17,26 @@
 #       ^ source.just string.quoted.single.just string.quoted.single.just
 #        ^^^^^^^^^^^^ source.just string.quoted.single.just
 #                    ^ source.just string.quoted.single.just
+>import? 'foo/bar.just'
+#^^^^^^ source.just keyword.other.reserved.just
+#      ^ source.just keyword.operator.optional.just
+#       ^ source.just
+#        ^ source.just string.quoted.single.just string.quoted.single.just
+#         ^^^^^^^^^^^^ source.just string.quoted.single.just
+#                     ^ source.just string.quoted.single.just
 >
 >mod bar
 #^^^ source.just keyword.other.reserved.just
 #   ^ source.just
-#    ^^^^ source.just
+#    ^^^ source.just variable.name.module.just
+>mod? bar
+#^^^ source.just keyword.other.reserved.just
+#   ^ source.just keyword.operator.optional.just
+#    ^ source.just
+#     ^^^ source.just variable.name.module.just
+>mode bar 'foo/bar.just'
+#^^^^^^^^^ source.just
+#         ^ source.just string.quoted.single.just string.quoted.single.just
+#          ^^^^^^^^^^^^ source.just string.quoted.single.just
+#                      ^ source.just string.quoted.single.just
 >

--- a/tests/general/general.just.snap
+++ b/tests/general/general.just.snap
@@ -34,9 +34,12 @@
 #   ^ source.just keyword.operator.optional.just
 #    ^ source.just
 #     ^^^ source.just variable.name.module.just
->mode bar 'foo/bar.just'
-#^^^^^^^^^ source.just
-#         ^ source.just string.quoted.single.just string.quoted.single.just
-#          ^^^^^^^^^^^^ source.just string.quoted.single.just
-#                      ^ source.just string.quoted.single.just
+>mod bar 'foo/bar.just'
+#^^^ source.just keyword.other.reserved.just
+#   ^ source.just
+#    ^^^ source.just variable.name.module.just
+#       ^ source.just
+#        ^ source.just string.quoted.single.just string.quoted.single.just
+#         ^^^^^^^^^^^^ source.just string.quoted.single.just
+#                     ^ source.just string.quoted.single.just
 >

--- a/tests/general/general.just.snap
+++ b/tests/general/general.just.snap
@@ -8,18 +8,6 @@
 #^^^^^^^^^^ source.just
 #          ^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
 >
-># Numbers
-#^^^^^^^^^ source.just comment.line.number-sign.just
->
->123
-#^^^ source.just constant.language.integer.just
-># TODO: should the "." be colored differently?
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
->123.456
-#^^^ source.just constant.language.integer.just
-#   ^ source.just
-#    ^^^ source.just constant.language.integer.just
->
 ># Imports
 #^^^^^^^^^ source.just comment.line.number-sign.just
 >

--- a/tests/general/general.just.snap
+++ b/tests/general/general.just.snap
@@ -19,7 +19,7 @@
 #                    ^ source.just string.quoted.single.just
 >import? 'foo/bar.just'
 #^^^^^^ source.just keyword.other.reserved.just
-#      ^ source.just keyword.operator.optional.just
+#      ^ source.just punctuation.optional.just
 #       ^ source.just
 #        ^ source.just string.quoted.single.just string.quoted.single.just
 #         ^^^^^^^^^^^^ source.just string.quoted.single.just
@@ -31,7 +31,7 @@
 #    ^^^ source.just variable.name.module.just
 >mod? bar
 #^^^ source.just keyword.other.reserved.just
-#   ^ source.just keyword.operator.optional.just
+#   ^ source.just punctuation.optional.just
 #    ^ source.just
 #     ^^^ source.just variable.name.module.just
 >mod bar 'foo/bar.just'

--- a/tests/general/multi-line-constructs.just
+++ b/tests/general/multi-line-constructs.just
@@ -1,9 +1,5 @@
 # Multi-line constructs
 
-# TODO: do we need to validate this?
-# TODO: just-specific highlighting in recipes be conditional (ex. only in interpolation blocks)
-# or always on?
-
 multi-line-recipe:
   if true; then \
     echo 'True!'; \
@@ -22,7 +18,7 @@ abc2 := (
   'c'
 )
 
-# TODO: multi-line recipe def broken
+# TODO: multi-line recipe def not supported
 
 foo param=('foo'
       + 'bar'

--- a/tests/general/multi-line-constructs.just
+++ b/tests/general/multi-line-constructs.just
@@ -1,7 +1,7 @@
 # Multi-line constructs
 
 # TODO: do we need to validate this?
-# TODO: should just-specific highlighting in recipes be conditional (ex. only in interpolation blocks)
+# TODO: just-specific highlighting in recipes be conditional (ex. only in interpolation blocks)
 # or always on?
 
 multi-line-recipe:

--- a/tests/general/multi-line-constructs.just.snap
+++ b/tests/general/multi-line-constructs.just.snap
@@ -34,8 +34,7 @@
 #^^^ source.just variable.other.just
 #   ^ source.just
 #    ^^ source.just keyword.operator.assignment.just
-#      ^ source.just
-#       ^ source.just
+#      ^^ source.just
 #        ^ source.just string.quoted.single.just string.quoted.single.just
 #         ^ source.just string.quoted.single.just
 #          ^ source.just string.quoted.single.just
@@ -53,14 +52,13 @@
 #           ^ source.just string.quoted.single.just string.quoted.single.just
 #            ^ source.just string.quoted.single.just
 #             ^ source.just string.quoted.single.just
-#              ^ source.just
+#              ^^ source.just
 >
 >abc2 := (
 #^^^^ source.just variable.other.just
 #    ^ source.just
 #     ^^ source.just keyword.operator.assignment.just
-#       ^ source.just
-#        ^ source.just
+#       ^^ source.just
 >  'a' +
 #^^ source.just
 #  ^ source.just string.quoted.single.just string.quoted.single.just
@@ -81,7 +79,7 @@
 #   ^ source.just string.quoted.single.just
 #    ^ source.just string.quoted.single.just
 >)
-#^ source.just
+#^^ source.just
 >
 ># TODO: multi-line recipe def broken
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
@@ -140,7 +138,7 @@
 #         ^ source.just string.quoted.single.just
 #          ^ source.just
 #           ^ source.just keyword.operator.concat.just
-#            ^^^ source.just
+#            ^^ source.just
 >     'bar'
 #^^^^^ source.just
 #     ^ source.just string.quoted.single.just string.quoted.single.just

--- a/tests/general/multi-line-constructs.just.snap
+++ b/tests/general/multi-line-constructs.just.snap
@@ -3,8 +3,8 @@
 >
 ># TODO: do we need to validate this?
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
-># TODO: should just-specific highlighting in recipes be conditional (ex. only in interpolation blocks)
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
+># TODO: just-specific highlighting in recipes be conditional (ex. only in interpolation blocks)
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
 ># or always on?
 #^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
 >

--- a/tests/general/multi-line-constructs.just.snap
+++ b/tests/general/multi-line-constructs.just.snap
@@ -34,7 +34,8 @@
 #^^^ source.just variable.other.just
 #   ^ source.just
 #    ^^ source.just keyword.operator.assignment.just
-#      ^^ source.just
+#      ^ source.just
+#       ^ source.just
 #        ^ source.just string.quoted.single.just string.quoted.single.just
 #         ^ source.just string.quoted.single.just
 #          ^ source.just string.quoted.single.just
@@ -52,13 +53,14 @@
 #           ^ source.just string.quoted.single.just string.quoted.single.just
 #            ^ source.just string.quoted.single.just
 #             ^ source.just string.quoted.single.just
-#              ^^ source.just
+#              ^ source.just
 >
 >abc2 := (
 #^^^^ source.just variable.other.just
 #    ^ source.just
 #     ^^ source.just keyword.operator.assignment.just
-#       ^^ source.just
+#       ^ source.just
+#        ^ source.just
 >  'a' +
 #^^ source.just
 #  ^ source.just string.quoted.single.just string.quoted.single.just
@@ -79,7 +81,7 @@
 #   ^ source.just string.quoted.single.just
 #    ^ source.just string.quoted.single.just
 >)
-#^^ source.just
+#^ source.just
 >
 ># TODO: multi-line recipe def broken
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just

--- a/tests/general/multi-line-constructs.just.snap
+++ b/tests/general/multi-line-constructs.just.snap
@@ -34,7 +34,8 @@
 #^^^ source.just variable.other.just
 #   ^ source.just
 #    ^^ source.just keyword.operator.assignment.just
-#      ^^ source.just
+#      ^ source.just
+#       ^ source.just
 #        ^ source.just string.quoted.single.just string.quoted.single.just
 #         ^ source.just string.quoted.single.just
 #          ^ source.just string.quoted.single.just
@@ -52,13 +53,14 @@
 #           ^ source.just string.quoted.single.just string.quoted.single.just
 #            ^ source.just string.quoted.single.just
 #             ^ source.just string.quoted.single.just
-#              ^^ source.just
+#              ^ source.just
 >
 >abc2 := (
 #^^^^ source.just variable.other.just
 #    ^ source.just
 #     ^^ source.just keyword.operator.assignment.just
-#       ^^^ source.just
+#       ^ source.just
+#        ^ source.just
 >  'a' +
 #^^ source.just
 #  ^ source.just string.quoted.single.just string.quoted.single.just
@@ -79,13 +81,14 @@
 #   ^ source.just string.quoted.single.just
 #    ^ source.just string.quoted.single.just
 >)
-#^^ source.just
+#^ source.just
 >
 ># TODO: multi-line recipe def broken
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
 >
 >foo param=('foo'
-#^^^^^^^^^^^ source.just
+#^^^^^^^^^^ source.just
+#          ^ source.just
 #           ^ source.just string.quoted.single.just string.quoted.single.just
 #            ^^^ source.just string.quoted.single.just
 #               ^ source.just string.quoted.single.just
@@ -97,7 +100,9 @@
 #         ^^^ source.just string.quoted.single.just
 #            ^ source.just string.quoted.single.just
 >    ):
-#^^^^^^^ source.just
+#^^^^ source.just
+#    ^ source.just
+#     ^^ source.just
 >  echo {{param}}
 #^^^^^^^ source.just
 #       ^^ source.just string.interpolated.escaping.just string.interpolated.escape.just

--- a/tests/general/multi-line-constructs.just.snap
+++ b/tests/general/multi-line-constructs.just.snap
@@ -1,13 +1,6 @@
 ># Multi-line constructs
 #^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
 >
-># TODO: do we need to validate this?
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
-># TODO: just-specific highlighting in recipes be conditional (ex. only in interpolation blocks)
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
-># or always on?
-#^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
->
 >multi-line-recipe:
 #^^^^^^^^^^^^^^^^^ source.just entity.name.function.just
 #                 ^ source.just keyword.operator.recipe.end.just
@@ -83,8 +76,8 @@
 >)
 #^ source.just
 >
-># TODO: multi-line recipe def broken
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
+># TODO: multi-line recipe def not supported
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
 >
 >foo param=('foo'
 #^^^^^^^^^^ source.just

--- a/tests/recipes/recipe-content.just
+++ b/tests/recipes/recipe-content.just
@@ -7,11 +7,5 @@ _private:
   echo hello
 
 body:
-  -echo "supress error"
+  -echo "suppress error"
   @echo quiet
-
-# Variables in recipes illegal
-
-# TODO: not implemented
-# foo:
-#   x := "hello"

--- a/tests/recipes/recipe-content.just.snap
+++ b/tests/recipes/recipe-content.just.snap
@@ -18,24 +18,15 @@
 >body:
 #^^^^ source.just entity.name.function.just
 #    ^ source.just keyword.operator.recipe.end.just
->  -echo "supress error"
+>  -echo "suppress error"
 #^^ source.just
 #  ^ source.just keyword.operator.error-suppression.just
 #   ^^^^^ source.just
 #        ^ source.just string.quoted.double.just string.quoted.double.just
-#         ^^^^^^^^^^^^^ source.just string.quoted.double.just
-#                      ^ source.just string.quoted.double.just
+#         ^^^^^^^^^^^^^^ source.just string.quoted.double.just
+#                       ^ source.just string.quoted.double.just
 >  @echo quiet
 #^^ source.just
 #  ^ source.just keyword.operator.quiet.just
 #   ^^^^^^^^^^^ source.just
 >
-># Variables in recipes illegal
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
->
-># TODO: not implemented
-#^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
-># foo:
-#^^^^^^ source.just comment.line.number-sign.just
->#   x := "hello"
-#^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just

--- a/tests/recipes/recipe-definition.just
+++ b/tests/recipes/recipe-definition.just
@@ -27,7 +27,6 @@ default_value a=("a" + ("b" + "c")):
 foo a=(arch + "-unknown-unknown") b=(arch / "input.dat"):
   echo {{a}} {{b}}
 
-# TODO: backticks broken
 a $A $B=`echo $A`:
   echo $A $B
 

--- a/tests/recipes/recipe-definition.just.snap
+++ b/tests/recipes/recipe-definition.just.snap
@@ -147,8 +147,6 @@
 #               ^ source.just string.interpolated.escaping.just
 #                ^^ source.just string.interpolated.escaping.just string.interpolated.escape.just
 >
-># TODO: backticks broken
-#^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
 >a $A $B=`echo $A`:
 #^ source.just entity.name.function.just
 # ^ source.just

--- a/tests/recipes/recipe-definition.just.snap
+++ b/tests/recipes/recipe-definition.just.snap
@@ -91,7 +91,8 @@
 #                   ^ source.just string.quoted.double.just
 #                    ^ source.just
 #                     ^ source.just keyword.operator.concat.just
-#                      ^^ source.just
+#                      ^ source.just
+#                       ^ source.just
 #                        ^ source.just string.quoted.double.just string.quoted.double.just
 #                         ^ source.just string.quoted.double.just
 #                          ^ source.just string.quoted.double.just
@@ -250,13 +251,15 @@
 #                ^ source.just
 #                 ^ source.just
 #                  ^^^^^ source.just entity.name.function.just
-#                       ^^ source.just
+#                       ^ source.just
+#                        ^ source.just
 #                         ^ source.just string.quoted.double.just string.quoted.double.just
 #                          ^ source.just string.quoted.double.just
 #                           ^ source.just string.quoted.double.just
 #                            ^ source.just
 #                             ^ source.just keyword.operator.concat.just
-#                              ^^ source.just
+#                              ^ source.just
+#                               ^ source.just
 #                                ^ source.just string.quoted.double.just string.quoted.double.just
 #                                 ^ source.just string.quoted.double.just
 #                                  ^ source.just string.quoted.double.just

--- a/tests/recipes/recipe-definition.just.snap
+++ b/tests/recipes/recipe-definition.just.snap
@@ -158,7 +158,9 @@
 #     ^ source.just keyword.other.recipe.variadic.just
 #      ^ source.just variable.parameter.recipe.just
 #       ^ source.just keyword.operator.default.just
-#        ^^^^^^^^^ source.just
+#        ^ source.just string.interpolated.just
+#         ^^^^^^^ source.just source.shell
+#                ^ source.just string.interpolated.just
 #                 ^ source.just keyword.operator.recipe.end.just
 >  echo $A $B
 #^^^^^^^^^^^^^ source.just

--- a/tests/statements/conditionals.just.snap
+++ b/tests/statements/conditionals.just.snap
@@ -27,7 +27,7 @@
 #                                        ^ source.just string.quoted.double.just string.quoted.double.just
 #                                         ^^^^ source.just string.quoted.double.just
 #                                             ^ source.just string.quoted.double.just
-#                                              ^^^ source.just
+#                                              ^^ source.just
 >foo := if "hello" != "goodbye" { "xyz" } else { "abc" }
 #^^^ source.just variable.other.just
 #   ^ source.just
@@ -54,7 +54,7 @@
 #                                                ^ source.just string.quoted.double.just string.quoted.double.just
 #                                                 ^^^ source.just string.quoted.double.just
 #                                                    ^ source.just string.quoted.double.just
-#                                                     ^^^ source.just
+#                                                     ^^ source.just
 >foo := if "hello" =~ 'hel+o' { "match" } else { "mismatch" }
 #^^^ source.just variable.other.just
 #   ^ source.just
@@ -81,7 +81,7 @@
 #                                                ^ source.just string.quoted.double.just string.quoted.double.just
 #                                                 ^^^^^^^^ source.just string.quoted.double.just
 #                                                         ^ source.just string.quoted.double.just
-#                                                          ^^^ source.just
+#                                                          ^^ source.just
 >foo := if env_var("RELEASE") == "true" { `get-something-from-release-database` } else { "dummy-value" }
 #^^^ source.just variable.other.just
 #   ^ source.just
@@ -94,8 +94,7 @@
 #                  ^ source.just string.quoted.double.just string.quoted.double.just
 #                   ^^^^^^^ source.just string.quoted.double.just
 #                          ^ source.just string.quoted.double.just
-#                           ^ source.just
-#                            ^ source.just
+#                           ^^ source.just
 #                             ^^ source.just keyword.operator.equality.just
 #                               ^ source.just
 #                                ^ source.just string.quoted.double.just string.quoted.double.just
@@ -111,7 +110,7 @@
 #                                                                                        ^ source.just string.quoted.double.just string.quoted.double.just
 #                                                                                         ^^^^^^^^^^^ source.just string.quoted.double.just
 #                                                                                                    ^ source.just string.quoted.double.just
-#                                                                                                     ^^^ source.just
+#                                                                                                     ^^ source.just
 >foo := if "hello" == "goodbye" {
 #^^^ source.just variable.other.just
 #   ^ source.just
@@ -128,7 +127,7 @@
 #                     ^ source.just string.quoted.double.just string.quoted.double.just
 #                      ^^^^^^^ source.just string.quoted.double.just
 #                             ^ source.just string.quoted.double.just
-#                              ^^^ source.just
+#                              ^^ source.just
 >  "xyz"
 #^^ source.just
 #  ^ source.just string.quoted.double.just string.quoted.double.just

--- a/tests/statements/conditionals.just.snap
+++ b/tests/statements/conditionals.just.snap
@@ -94,7 +94,8 @@
 #                  ^ source.just string.quoted.double.just string.quoted.double.just
 #                   ^^^^^^^ source.just string.quoted.double.just
 #                          ^ source.just string.quoted.double.just
-#                           ^^ source.just
+#                           ^ source.just
+#                            ^ source.just
 #                             ^^ source.just keyword.operator.equality.just
 #                               ^ source.just
 #                                ^ source.just string.quoted.double.just string.quoted.double.just

--- a/tests/statements/interpolation.just
+++ b/tests/statements/interpolation.just
@@ -1,6 +1,7 @@
 # Interpolation blocks
 
-# TODO: interpolation blocks don't really work highlighting-wise
+# TODO: interpolation blocks always color as strings since we can't
+# effectively push scope for nested string/escape blocks
 
 base:
   echo {{var}} {{ var }}
@@ -20,7 +21,7 @@ escaped:
   echo '{{ "{{" }} var }}'
   echo {{ "{{" }} var }}
   echo '{{'{{ var }}'}}'
-  # TODO: broken
+  # TODO: broken nesting
   # echo {{ '{{ var }}' }}
   # echo {{ "{{ var" }} }}
   # echo {{ "{{ 'var' }}" }}

--- a/tests/statements/interpolation.just.snap
+++ b/tests/statements/interpolation.just.snap
@@ -1,8 +1,10 @@
 ># Interpolation blocks
 #^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
 >
-># TODO: interpolation blocks don't really work highlighting-wise
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
+># TODO: interpolation blocks always color as strings since we can't
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
+># effectively push scope for nested string/escape blocks
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
 >
 >base:
 #^^^^ source.just entity.name.function.just
@@ -126,9 +128,9 @@
 #                    ^ source.just string.quoted.single.just string.quoted.single.just
 #                     ^^ source.just string.quoted.single.just
 #                       ^ source.just string.quoted.single.just
->  # TODO: broken
+>  # TODO: broken nesting
 #^^ source.just
-#  ^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
+#  ^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
 >  # echo {{ '{{ var }}' }}
 #^^ source.just
 #  ^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just

--- a/tests/variables/settings.just.snap
+++ b/tests/variables/settings.just.snap
@@ -4,7 +4,7 @@
 >set allow-duplicate-recipes := true
 #^^^ source.just keyword.other.reserved.just
 #   ^ source.just
-#    ^^^^^^^^^^^^^^^^^^^^^^^ source.just variable.language.setting.just
+#    ^^^^^^^^^^^^^^^^^^^^^^^ source.just variable.other.just
 #                           ^ source.just
 #                            ^^ source.just keyword.operator.assignment.just
 #                              ^ source.just
@@ -12,7 +12,7 @@
 >set allow-duplicate-variables := true
 #^^^ source.just keyword.other.reserved.just
 #   ^ source.just
-#    ^^^^^^^^^^^^^^^^^^^^^^^^^ source.just variable.language.setting.just
+#    ^^^^^^^^^^^^^^^^^^^^^^^^^ source.just variable.other.just
 #                             ^ source.just
 #                              ^^ source.just keyword.operator.assignment.just
 #                                ^ source.just
@@ -20,7 +20,7 @@
 >set dotenv-filename := ".env"
 #^^^ source.just keyword.other.reserved.just
 #   ^ source.just
-#    ^^^^^^^^^^^^^^^ source.just variable.language.setting.just
+#    ^^^^^^^^^^^^^^^ source.just variable.other.just
 #                   ^ source.just
 #                    ^^ source.just keyword.operator.assignment.just
 #                      ^ source.just
@@ -30,7 +30,7 @@
 >set dotenv-load := true
 #^^^ source.just keyword.other.reserved.just
 #   ^ source.just
-#    ^^^^^^^^^^^ source.just variable.language.setting.just
+#    ^^^^^^^^^^^ source.just variable.other.just
 #               ^ source.just
 #                ^^ source.just keyword.operator.assignment.just
 #                  ^ source.just
@@ -38,7 +38,7 @@
 >set dotenv-path := "."
 #^^^ source.just keyword.other.reserved.just
 #   ^ source.just
-#    ^^^^^^^^^^^ source.just variable.language.setting.just
+#    ^^^^^^^^^^^ source.just variable.other.just
 #               ^ source.just
 #                ^^ source.just keyword.operator.assignment.just
 #                  ^ source.just
@@ -48,7 +48,7 @@
 >set dotenv-required := false
 #^^^ source.just keyword.other.reserved.just
 #   ^ source.just
-#    ^^^^^^^^^^^^^^^ source.just variable.language.setting.just
+#    ^^^^^^^^^^^^^^^ source.just variable.other.just
 #                   ^ source.just
 #                    ^^ source.just keyword.operator.assignment.just
 #                      ^ source.just
@@ -56,7 +56,7 @@
 >set export := true
 #^^^ source.just keyword.other.reserved.just
 #   ^ source.just
-#    ^^^^^^ source.just variable.language.setting.just
+#    ^^^^^^ source.just variable.other.just
 #          ^ source.just
 #           ^^ source.just keyword.operator.assignment.just
 #             ^ source.just
@@ -64,7 +64,7 @@
 >set fallback := true
 #^^^ source.just keyword.other.reserved.just
 #   ^ source.just
-#    ^^^^^^^^ source.just variable.language.setting.just
+#    ^^^^^^^^ source.just variable.other.just
 #            ^ source.just
 #             ^^ source.just keyword.operator.assignment.just
 #               ^ source.just
@@ -72,7 +72,7 @@
 >set ignore-comments := false
 #^^^ source.just keyword.other.reserved.just
 #   ^ source.just
-#    ^^^^^^^^^^^^^^^ source.just variable.language.setting.just
+#    ^^^^^^^^^^^^^^^ source.just variable.other.just
 #                   ^ source.just
 #                    ^^ source.just keyword.operator.assignment.just
 #                      ^ source.just
@@ -80,7 +80,7 @@
 >set positional-arguments := true
 #^^^ source.just keyword.other.reserved.just
 #   ^ source.just
-#    ^^^^^^^^^^^^^^^^^^^^ source.just variable.language.setting.just
+#    ^^^^^^^^^^^^^^^^^^^^ source.just variable.other.just
 #                        ^ source.just
 #                         ^^ source.just keyword.operator.assignment.just
 #                           ^ source.just
@@ -88,7 +88,7 @@
 >set shell := ["bash", "-uc"]
 #^^^ source.just keyword.other.reserved.just
 #   ^ source.just
-#    ^^^^^ source.just variable.language.setting.just
+#    ^^^^^ source.just variable.other.just
 #         ^ source.just
 #          ^^ source.just keyword.operator.assignment.just
 #            ^^ source.just
@@ -99,11 +99,11 @@
 #                      ^ source.just string.quoted.double.just string.quoted.double.just
 #                       ^^^ source.just string.quoted.double.just
 #                          ^ source.just string.quoted.double.just
-#                           ^^ source.just
+#                           ^ source.just
 >set tempdir := "/tmp"
 #^^^ source.just keyword.other.reserved.just
 #   ^ source.just
-#    ^^^^^^^ source.just variable.language.setting.just
+#    ^^^^^^^ source.just variable.other.just
 #           ^ source.just
 #            ^^ source.just keyword.operator.assignment.just
 #              ^ source.just
@@ -113,7 +113,7 @@
 >set windows-powershell := false
 #^^^ source.just keyword.other.reserved.just
 #   ^ source.just
-#    ^^^^^^^^^^^^^^^^^^ source.just variable.language.setting.just
+#    ^^^^^^^^^^^^^^^^^^ source.just variable.other.just
 #                      ^ source.just
 #                       ^^ source.just keyword.operator.assignment.just
 #                         ^ source.just
@@ -121,7 +121,7 @@
 >set windows-shell := "cmd"
 #^^^ source.just keyword.other.reserved.just
 #   ^ source.just
-#    ^^^^^^^^^^^^^ source.just variable.language.setting.just
+#    ^^^^^^^^^^^^^ source.just variable.other.just
 #                 ^ source.just
 #                  ^^ source.just keyword.operator.assignment.just
 #                    ^ source.just
@@ -135,5 +135,5 @@
 >set allow-duplicate-recipes
 #^^^ source.just keyword.other.reserved.just
 #   ^ source.just
-#    ^^^^^^^^^^^^^^^^^^^^^^^ source.just variable.language.setting.just
+#    ^^^^^^^^^^^^^^^^^^^^^^^ source.just variable.other.just
 >

--- a/tests/variables/variables.just.snap
+++ b/tests/variables/variables.just.snap
@@ -5,7 +5,7 @@
 >alias b := build
 #^^^^^ source.just keyword.other.reserved.just
 #     ^ source.just
-#      ^ source.just variable.other.just
+#      ^ source.just variable.name.alias.just
 #       ^ source.just
 #        ^^ source.just keyword.operator.assignment.just
 #          ^ source.just
@@ -13,7 +13,7 @@
 >alias help-123 := some-recipe
 #^^^^^ source.just keyword.other.reserved.just
 #     ^ source.just
-#      ^^^^^^^^ source.just variable.other.just
+#      ^^^^^^^^ source.just variable.name.alias.just
 #              ^ source.just
 #               ^^ source.just keyword.operator.assignment.just
 #                 ^ source.just

--- a/tests/variables/variables.just.snap
+++ b/tests/variables/variables.just.snap
@@ -3,19 +3,21 @@
 #^^^^^^^^^ source.just comment.line.number-sign.just
 >
 >alias b := build
-#^^^^^ source.just keyword.other.assignment.just
+#^^^^^ source.just keyword.other.reserved.just
 #     ^ source.just
 #      ^ source.just variable.other.just
 #       ^ source.just
 #        ^^ source.just keyword.operator.assignment.just
-#          ^^^^^^^ source.just
+#          ^ source.just
+#           ^^^^^ source.just variable.other.just
 >alias help-123 := some-recipe
-#^^^^^ source.just keyword.other.assignment.just
+#^^^^^ source.just keyword.other.reserved.just
 #     ^ source.just
 #      ^^^^^^^^ source.just variable.other.just
 #              ^ source.just
 #               ^^ source.just keyword.operator.assignment.just
-#                 ^^^^^^^^^^^^^ source.just
+#                 ^ source.just
+#                  ^^^^^^^^^^^ source.just variable.other.just
 >
 ># Variables and substitution
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just

--- a/tests/variables/variables.just.snap
+++ b/tests/variables/variables.just.snap
@@ -50,7 +50,7 @@
 #                                  ^ source.just string.quoted.double.just
 #                                   ^ source.just
 #                                    ^ source.just keyword.operator.concat.just
-#                                     ^^^^^^^^^ source.just
+#                                     ^^^^^^^^ source.just
 >tarball := tardir + ".tar.gz"
 #^^^^^^^ source.just variable.other.just
 #       ^ source.just
@@ -85,7 +85,7 @@
 #^^^^^^^^^ source.just comment.line.number-sign.just
 >
 >export RUST_BACKTRACE := "1"
-#^^^^^^ source.just keyword.other.assignment.just
+#^^^^^^ source.just keyword.other.reserved.just
 #      ^ source.just
 #       ^^^^^^^^^^^^^^ source.just variable.other.just
 #                     ^ source.just


### PR DESCRIPTION
**Description:**

- Moves around and refactors rules to match the breakdown of the `just` grammar somewhat more closely (still not great but getting a little closer to what textmate can reasonably support)
- Cleans up inconsistent scopes being applied to the same tokens (ex. `export` being a reserved vs assignment keyword). Additional followup to improve scope names and provide a master list of scopes will be another PR
- Corrects issue with backticks include incorrectly names in recipe definitions
- Broke down long regexes in a more readable format 
- Updates readme on limitations of the extension

**Testing/Screenshots:**

- Updated snapshots
