### PR TITLE
🔨 Unicode codepoint escaped characters in strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Unicode codepoint escaped characters in strings from `just` release 1.36.0
+
 ## [0.5.3] - 2024-08-14
 
 ### Changed

--- a/syntaxes/just.tmLanguage.json
+++ b/syntaxes/just.tmLanguage.json
@@ -378,7 +378,7 @@
             {
               "comment": "Escaped characters",
               "name": "constant.character.escape.just",
-              "match": "\\\\."
+              "match": "\\\\.(?:(?<=u)\\{.+?\\})?"
             },
             {
               "include": "#escaping"
@@ -402,7 +402,7 @@
             {
               "comment": "Escaped characters",
               "name": "constant.character.escape.just",
-              "match": "\\\\."
+              "match": "\\\\.(?:(?<=u)\\{.+?\\})?"
             },
             {
               "include": "#escaping"

--- a/syntaxes/just.tmLanguage.yml
+++ b/syntaxes/just.tmLanguage.yml
@@ -267,7 +267,7 @@ repository:
         patterns:
           - comment: Escaped characters
             name: constant.character.escape.just
-            match: "\\\\."
+            match: "\\\\.(?:(?<=u)\\{.+?\\})?"
           - include: '#escaping'
       - comment: String
         name: string.quoted.double.just
@@ -281,7 +281,7 @@ repository:
         patterns:
           - comment: Escaped characters
             name: constant.character.escape.just
-            match: "\\\\."
+            match: "\\\\.(?:(?<=u)\\{.+?\\})?"
           - include: '#escaping'
       - comment: Indented raw string
         name: string.quoted.single.indented.just

--- a/syntaxes/tests/statements/strings.just
+++ b/syntaxes/tests/statements/strings.just
@@ -6,17 +6,19 @@ single-quote := "don't be afraid of contractions"
 
 # Escaping sequences
 
-string-with-tab             := "\t"
-string-with-newline         := "\n"
-string-with-carriage-return := "\r"
-string-with-double-quote    := "\""
-string-with-slash           := "\\"
-string-with-no-newline      := "\
+carriage-return   := "\r"
+double-quote      := "\""
+newline           := "\n"
+no-newline        := "\
 "
+slash             := "\\"
+tab               := "\t"
+unicode-codepoint := "\u{1F916}"
+non-unicode-not-escaped := "\a{1F916}"
 
-escapes := """\t\n\r\"\\"""
-escapes := '\t\n\r\"\\'
-escapes := '''\t\n\r\"\\'''
+escapes := """\t\n\r\"\u{123}\\"""
+escapes := '\t\n\r\"\u{123}\\'
+escapes := '''\t\n\r\"\u{123}\\'''
 
 # Multi-line
 

--- a/syntaxes/tests/statements/strings.just.snap
+++ b/syntaxes/tests/statements/strings.just.snap
@@ -16,57 +16,74 @@
 ># Escaping sequences
 #^^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.just
 >
->string-with-tab             := "\t"
+>carriage-return   := "\r"
 #^^^^^^^^^^^^^^^ source.just variable.other.just
-#               ^^^^^^^^^^^^^ source.just
-#                            ^^ source.just keyword.operator.assignment.just
-#                              ^ source.just
-#                               ^ source.just string.quoted.double.just string.quoted.double.just
-#                                ^^ source.just string.quoted.double.just constant.character.escape.just
-#                                  ^ source.just string.quoted.double.just
->string-with-newline         := "\n"
-#^^^^^^^^^^^^^^^^^^^ source.just variable.other.just
-#                   ^^^^^^^^^ source.just
-#                            ^^ source.just keyword.operator.assignment.just
-#                              ^ source.just
-#                               ^ source.just string.quoted.double.just string.quoted.double.just
-#                                ^^ source.just string.quoted.double.just constant.character.escape.just
-#                                  ^ source.just string.quoted.double.just
->string-with-carriage-return := "\r"
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.just variable.other.just
-#                           ^ source.just
-#                            ^^ source.just keyword.operator.assignment.just
-#                              ^ source.just
-#                               ^ source.just string.quoted.double.just string.quoted.double.just
-#                                ^^ source.just string.quoted.double.just constant.character.escape.just
-#                                  ^ source.just string.quoted.double.just
->string-with-double-quote    := "\""
-#^^^^^^^^^^^^^^^^^^^^^^^^ source.just variable.other.just
-#                        ^^^^ source.just
-#                            ^^ source.just keyword.operator.assignment.just
-#                              ^ source.just
-#                               ^ source.just string.quoted.double.just string.quoted.double.just
-#                                ^^ source.just string.quoted.double.just constant.character.escape.just
-#                                  ^ source.just string.quoted.double.just
->string-with-slash           := "\\"
-#^^^^^^^^^^^^^^^^^ source.just variable.other.just
-#                 ^^^^^^^^^^^ source.just
-#                            ^^ source.just keyword.operator.assignment.just
-#                              ^ source.just
-#                               ^ source.just string.quoted.double.just string.quoted.double.just
-#                                ^^ source.just string.quoted.double.just constant.character.escape.just
-#                                  ^ source.just string.quoted.double.just
->string-with-no-newline      := "\
-#^^^^^^^^^^^^^^^^^^^^^^ source.just variable.other.just
-#                      ^^^^^^ source.just
-#                            ^^ source.just keyword.operator.assignment.just
-#                              ^ source.just
-#                               ^ source.just string.quoted.double.just string.quoted.double.just
-#                                ^^ source.just string.quoted.double.just
+#               ^^^ source.just
+#                  ^^ source.just keyword.operator.assignment.just
+#                    ^ source.just
+#                     ^ source.just string.quoted.double.just string.quoted.double.just
+#                      ^^ source.just string.quoted.double.just constant.character.escape.just
+#                        ^ source.just string.quoted.double.just
+>double-quote      := "\""
+#^^^^^^^^^^^^ source.just variable.other.just
+#            ^^^^^^ source.just
+#                  ^^ source.just keyword.operator.assignment.just
+#                    ^ source.just
+#                     ^ source.just string.quoted.double.just string.quoted.double.just
+#                      ^^ source.just string.quoted.double.just constant.character.escape.just
+#                        ^ source.just string.quoted.double.just
+>newline           := "\n"
+#^^^^^^^ source.just variable.other.just
+#       ^^^^^^^^^^^ source.just
+#                  ^^ source.just keyword.operator.assignment.just
+#                    ^ source.just
+#                     ^ source.just string.quoted.double.just string.quoted.double.just
+#                      ^^ source.just string.quoted.double.just constant.character.escape.just
+#                        ^ source.just string.quoted.double.just
+>no-newline        := "\
+#^^^^^^^^^^ source.just variable.other.just
+#          ^^^^^^^^ source.just
+#                  ^^ source.just keyword.operator.assignment.just
+#                    ^ source.just
+#                     ^ source.just string.quoted.double.just string.quoted.double.just
+#                      ^^ source.just string.quoted.double.just
 >"
 #^ source.just string.quoted.double.just
+>slash             := "\\"
+#^^^^^ source.just variable.other.just
+#     ^^^^^^^^^^^^^ source.just
+#                  ^^ source.just keyword.operator.assignment.just
+#                    ^ source.just
+#                     ^ source.just string.quoted.double.just string.quoted.double.just
+#                      ^^ source.just string.quoted.double.just constant.character.escape.just
+#                        ^ source.just string.quoted.double.just
+>tab               := "\t"
+#^^^ source.just variable.other.just
+#   ^^^^^^^^^^^^^^^ source.just
+#                  ^^ source.just keyword.operator.assignment.just
+#                    ^ source.just
+#                     ^ source.just string.quoted.double.just string.quoted.double.just
+#                      ^^ source.just string.quoted.double.just constant.character.escape.just
+#                        ^ source.just string.quoted.double.just
+>unicode-codepoint := "\u{1F916}"
+#^^^^^^^^^^^^^^^^^ source.just variable.other.just
+#                 ^ source.just
+#                  ^^ source.just keyword.operator.assignment.just
+#                    ^ source.just
+#                     ^ source.just string.quoted.double.just string.quoted.double.just
+#                      ^^^^^^^^^ source.just string.quoted.double.just constant.character.escape.just
+#                               ^ source.just string.quoted.double.just
+>non-unicode-not-escaped := "\a{1F916}"
+#^^^^^^^^^^^^^^^^^^^^^^^ source.just variable.other.just
+#                       ^ source.just
+#                        ^^ source.just keyword.operator.assignment.just
+#                          ^ source.just
+#                           ^ source.just string.quoted.double.just string.quoted.double.just
+#                            ^^ source.just string.quoted.double.just constant.character.escape.just
+#                              ^^^^^^^ source.just string.quoted.double.just
+#                                     ^ source.just string.quoted.double.just
 >
->escapes := """\t\n\r\"\\"""
+>escapes := """\t\n\r\"\u{123}\\"""
 #^^^^^^^ source.just variable.other.just
 #       ^ source.just
 #        ^^ source.just keyword.operator.assignment.just
@@ -76,24 +93,25 @@
 #                ^^ source.just string.quoted.double.indented.just constant.character.escape.just
 #                  ^^ source.just string.quoted.double.indented.just constant.character.escape.just
 #                    ^^ source.just string.quoted.double.indented.just constant.character.escape.just
-#                      ^^ source.just string.quoted.double.indented.just constant.character.escape.just
-#                        ^^^ source.just string.quoted.double.indented.just
->escapes := '\t\n\r\"\\'
+#                      ^^^^^^^ source.just string.quoted.double.indented.just constant.character.escape.just
+#                             ^^ source.just string.quoted.double.indented.just constant.character.escape.just
+#                               ^^^ source.just string.quoted.double.indented.just
+>escapes := '\t\n\r\"\u{123}\\'
 #^^^^^^^ source.just variable.other.just
 #       ^ source.just
 #        ^^ source.just keyword.operator.assignment.just
 #          ^ source.just
 #           ^ source.just string.quoted.single.just string.quoted.single.just
-#            ^^^^^^^^^^ source.just string.quoted.single.just
-#                      ^ source.just string.quoted.single.just
->escapes := '''\t\n\r\"\\'''
+#            ^^^^^^^^^^^^^^^^^ source.just string.quoted.single.just
+#                             ^ source.just string.quoted.single.just
+>escapes := '''\t\n\r\"\u{123}\\'''
 #^^^^^^^ source.just variable.other.just
 #       ^ source.just
 #        ^^ source.just keyword.operator.assignment.just
 #          ^ source.just
 #           ^^^ source.just string.quoted.single.indented.just string.quoted.single.indented.just
-#              ^^^^^^^^^^ source.just string.quoted.single.indented.just
-#                        ^^^ source.just string.quoted.single.indented.just
+#              ^^^^^^^^^^^^^^^^^ source.just string.quoted.single.indented.just
+#                               ^^^ source.just string.quoted.single.indented.just
 >
 ># Multi-line
 #^^^^^^^^^^^^ source.just comment.line.number-sign.just


### PR DESCRIPTION
**Description:**

- Unicode codepoint escaped characters in strings from `just` release 1.36.0

**Testing/Screenshots:**

- Snapshot and local testing