### PR TITLE
✨ Add `editor.defaultFormatter` support

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -1,4 +1,16 @@
+import child_process from 'node:child_process';
+import util from 'node:util';
+
 import { spawn } from 'child_process';
+
+const exec = util.promisify(child_process.exec);
+
+async function lsExample() {
+  const { stdout, stderr } = await exec('ls');
+  console.log('stdout:', stdout);
+  console.error('stderr:', stderr);
+}
+lsExample();
 
 import { getLogger } from './logger';
 import { getJustPath } from './utils';
@@ -21,4 +33,21 @@ export const formatWithExecutable = (fsPath: string) => {
   childProcess.on('close', (code) => {
     console.debug(`just --fmt exited with ${code}`);
   });
+};
+
+/**
+ * Uses --dump to format the file and return the formatted content.
+ *
+ * @param fsPath - The path to the file to format.
+ * @returns A promise that resolves to the formatted content.
+ */
+export const dumpWithExecutable = async (fsPath: string): Promise<string> => {
+  const { stdout, stderr } = await exec(`${getJustPath()} -f ${fsPath} --dump`);
+
+  if (stderr.length > 0) {
+    LOGGER.error(`Error formatting '${fsPath}':\n${stderr}`);
+    throw new Error(`Error formatting '${fsPath}'. See output for more info.`);
+  }
+
+  return stdout;
 };


### PR DESCRIPTION
**Description:**

This adds support for registering `vscode-just` as a formatter in VSCode. It fixes the issue identified in #78 

Uses the `--dump` flag in the `just` CLI to write the formatted output to the file using VSCode's TextEdit API.

**Testing/Screenshots:**

<img width="443" height="94" alt="image" src="https://github.com/user-attachments/assets/b9e1b315-2828-4219-b2ff-bb5bc5d59bbf" />
