### PR TITLE
🩹 Use workspace root when running just-lsp

### DIFF
--- a/src/lsp.ts
+++ b/src/lsp.ts
@@ -19,9 +19,10 @@ export const createLanguageClient = async (): Promise<LanguageClient | null> => 
 
   const isAvailable = await checkLspAvailability(lspPath);
   if (!isAvailable) {
+    LOGGER.warning(`Just LSP binary not found at path: ${lspPath}.`);
     vscode.window
       .showWarningMessage(
-        `Just LSP binary found but not working: ${lspPath}. Please check the installation or configure the path in settings.`,
+        `Just LSP binary not found at path: ${lspPath}. Please check the installation or configure the path in settings.`,
         'Install Instructions',
       )
       .then((selection) => {


### PR DESCRIPTION
**Description:**

Re https://github.com/nefrob/vscode-just/issues/90.

- Set workspace root as the current working directory when spawning the LSP binary. This allows version managers (mise, asdf, rtx, etc.) to properly resolve tool versions based on project configuration files.


**Testing/Screenshots:**

- Validated update works with mise install `/Users/robertneff/.local/share/mise/installs/cargo-just-lsp/0.3.4/bin/just-lsp`
 