### PR TITLE
🩹 Fix HereDoc syntax highlighting bleeding into subsequent recipes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 *.justfile
 *.md
 *.snap
+syntaxes/test-grammars/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix shell HereDoc syntax highlighting bleeding into subsequent recipes by replacing `end` with `while` in embedded language rules
+
 ## [0.10.0] - 2026-03-22
 
 ### Fixed

--- a/syntaxes/just.tmLanguage.json
+++ b/syntaxes/just.tmLanguage.json
@@ -2,11 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "Just",
   "scopeName": "source.just",
-  "fileTypes": [
-    "just",
-    "justfile",
-    "Justfile"
-  ],
+  "fileTypes": ["just", "justfile", "Justfile"],
   "firstLineMatch": "#![\\s\\t]*\\/.*\\just\\b",
   "uuid": "8b0cfae0-229f-4688-a4b7-8b5c3db82855",
   "patterns": [
@@ -673,7 +669,7 @@
         {
           "comment": "JavaScript",
           "begin": "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?node.*)$",
-          "end": "(?=^[^\\s])",
+          "while": "^(?=\\s*$|\\s)",
           "beginCaptures": {
             "1": {
               "name": "comment.line.number-sign.shebang.just"
@@ -689,7 +685,7 @@
         {
           "comment": "Deno",
           "begin": "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?deno.*)$",
-          "end": "(?=^[^\\s])",
+          "while": "^(?=\\s*$|\\s)",
           "beginCaptures": {
             "1": {
               "name": "comment.line.number-sign.shebang.just"
@@ -705,7 +701,7 @@
         {
           "comment": "Perl",
           "begin": "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?perl.*)$",
-          "end": "(?=^[^\\s])",
+          "while": "^(?=\\s*$|\\s)",
           "beginCaptures": {
             "1": {
               "name": "comment.line.number-sign.shebang.just"
@@ -721,7 +717,7 @@
         {
           "comment": "Python",
           "begin": "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?python.*)$",
-          "end": "(?=^[^\\s])",
+          "while": "^(?=\\s*$|\\s)",
           "beginCaptures": {
             "1": {
               "name": "comment.line.number-sign.shebang.just"
@@ -737,7 +733,7 @@
         {
           "comment": "Ruby",
           "begin": "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?ruby.*)$",
-          "end": "(?=^[^\\s])",
+          "while": "^(?=\\s*$|\\s)",
           "beginCaptures": {
             "1": {
               "name": "comment.line.number-sign.shebang.just"
@@ -753,7 +749,7 @@
         {
           "comment": "Shell",
           "begin": "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?(?:sh|bash|zsh|fish).*)$",
-          "end": "(?=^[^\\s])",
+          "while": "^(?=\\s*$|\\s)",
           "beginCaptures": {
             "1": {
               "name": "comment.line.number-sign.shebang.just"

--- a/syntaxes/just.tmLanguage.json
+++ b/syntaxes/just.tmLanguage.json
@@ -2,7 +2,11 @@
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "Just",
   "scopeName": "source.just",
-  "fileTypes": ["just", "justfile", "Justfile"],
+  "fileTypes": [
+    "just",
+    "justfile",
+    "Justfile"
+  ],
   "firstLineMatch": "#![\\s\\t]*\\/.*\\just\\b",
   "uuid": "8b0cfae0-229f-4688-a4b7-8b5c3db82855",
   "patterns": [

--- a/syntaxes/just.tmLanguage.yml
+++ b/syntaxes/just.tmLanguage.yml
@@ -491,10 +491,15 @@ repository:
         name: keyword.operator.and.just
 
   embedded-languages:
+    # Use `while` instead of `end` for indented shebang blocks.
+    # VSCode’s TextMate `while` prevents inner rules from escaping,
+    # avoiding the indented EOT/EOF HereDoc highlighting bug:
+    # https://github.com/jeff-hykin/better-shell-syntax/issues/97
+    # https://github.com/RedCMD/TmLanguage-Syntax-Highlighter/blob/main/documentation/rules.md#while
     patterns:
       - comment: JavaScript
         begin: "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?node.*)$"
-        end: (?=^[^\s])
+        while: "^(?=\\s*$|\\s)"
         beginCaptures:
           '1':
             name: comment.line.number-sign.shebang.just
@@ -503,7 +508,7 @@ repository:
           - include: source.js
       - comment: Deno
         begin: "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?deno.*)$"
-        end: (?=^[^\s])
+        while: "^(?=\\s*$|\\s)"
         beginCaptures:
           '1':
             name: comment.line.number-sign.shebang.just
@@ -512,7 +517,7 @@ repository:
           - include: source.ts
       - comment: Perl
         begin: "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?perl.*)$"
-        end: (?=^[^\s])
+        while: "^(?=\\s*$|\\s)"
         beginCaptures:
           '1':
             name: comment.line.number-sign.shebang.just
@@ -521,7 +526,7 @@ repository:
           - include: source.perl
       - comment: Python
         begin: "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?python.*)$"
-        end: (?=^[^\s])
+        while: "^(?=\\s*$|\\s)"
         beginCaptures:
           '1':
             name: comment.line.number-sign.shebang.just
@@ -530,7 +535,7 @@ repository:
           - include: source.python
       - comment: Ruby
         begin: "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?ruby.*)$"
-        end: (?=^[^\s])
+        while: "^(?=\\s*$|\\s)"
         beginCaptures:
           '1':
             name: comment.line.number-sign.shebang.just
@@ -539,7 +544,7 @@ repository:
           - include: source.ruby
       - comment: Shell
         begin: "^\\s+(#!/usr/bin/env\\s+(?:-S\\s+)?(?:sh|bash|zsh|fish).*)$"
-        end: (?=^[^\s])
+        while: "^(?=\\s*$|\\s)"
         beginCaptures:
           '1':
             name: comment.line.number-sign.shebang.just

--- a/syntaxes/tests/embedded/embedded_language_bounds.just
+++ b/syntaxes/tests/embedded/embedded_language_bounds.just
@@ -44,7 +44,7 @@ sh-eof:
     EOF
     echo "done"
 
-another-sh-eof:
+another-sh-recipe:
     #!/usr/bin/env bash
     echo "still works"
 

--- a/syntaxes/tests/embedded/embedded_language_bounds.just
+++ b/syntaxes/tests/embedded/embedded_language_bounds.just
@@ -36,3 +36,20 @@ python-with-deps-on-multiple-lines: \
         def __init__(self, hello):
             self.hello = hello
     print('Hello from python!')
+
+sh-eof:
+    #!/usr/bin/env bash
+    cat <<'EOF'
+    hello
+    EOF
+    echo "done"
+
+another-sh-eof:
+    #!/usr/bin/env bash
+    echo "still works"
+
+sh-varying-indent:
+    #!/usr/bin/env bash
+    echo "base indent"
+        echo "more indented"
+    echo "back to base"

--- a/syntaxes/tests/embedded/embedded_language_bounds.just.snap
+++ b/syntaxes/tests/embedded/embedded_language_bounds.just.snap
@@ -243,9 +243,9 @@
 >    echo "done"
 #^^^^^^^^^^^^^^^^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell string.quoted.heredoc.no-indent.EOF
 >
->another-sh-eof:
-#^^^^^^^^^^^^^^ source.just entity.name.function.just
-#              ^ source.just keyword.operator.recipe.end.just
+>another-sh-recipe:
+#^^^^^^^^^^^^^^^^^ source.just entity.name.function.just
+#                 ^ source.just keyword.operator.recipe.end.just
 >    #!/usr/bin/env bash
 #^^^^ source.just
 #    ^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.shebang.just

--- a/syntaxes/tests/embedded/embedded_language_bounds.just.snap
+++ b/syntaxes/tests/embedded/embedded_language_bounds.just.snap
@@ -222,3 +222,66 @@
 #                             ^ source.just source.python meta.function-call.python meta.function-call.arguments.python string.quoted.single.python punctuation.definition.string.end.python
 #                              ^ source.just source.python meta.function-call.python punctuation.definition.arguments.end.python
 >
+>sh-eof:
+#^^^^^^ source.just entity.name.function.just
+#      ^ source.just keyword.operator.recipe.end.just
+>    #!/usr/bin/env bash
+#^^^^ source.just
+#    ^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.shebang.just
+>    cat <<'EOF'
+#^^^^ source.just source.shell meta.statement.shell
+#    ^^^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.statement.command.name.shell entity.name.function.call.shell entity.name.command.shell
+#       ^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell
+#        ^^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell keyword.operator.heredoc.shell
+#          ^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell punctuation.definition.string.heredoc.quote.shell
+#           ^^^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell punctuation.definition.string.heredoc.delimiter.shell
+#              ^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell punctuation.definition.string.heredoc.quote.shell
+>    hello
+#^^^^^^^^^^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell string.quoted.heredoc.no-indent.EOF
+>    EOF
+#^^^^^^^^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell string.quoted.heredoc.no-indent.EOF
+>    echo "done"
+#^^^^^^^^^^^^^^^^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell string.quoted.heredoc.no-indent.EOF
+>
+>another-sh-eof:
+#^^^^^^^^^^^^^^ source.just entity.name.function.just
+#              ^ source.just keyword.operator.recipe.end.just
+>    #!/usr/bin/env bash
+#^^^^ source.just
+#    ^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.shebang.just
+>    echo "still works"
+#^^^^ source.just source.shell meta.statement.shell
+#    ^^^^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.statement.command.name.shell entity.name.function.call.shell entity.name.command.shell support.function.builtin.shell
+#        ^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell
+#         ^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell string.quoted.double.shell punctuation.definition.string.begin.shell
+#          ^^^^^^^^^^^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell string.quoted.double.shell
+#                     ^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell string.quoted.double.shell punctuation.definition.string.end.shell
+>
+>sh-varying-indent:
+#^^^^^^^^^^^^^^^^^ source.just entity.name.function.just
+#                 ^ source.just keyword.operator.recipe.end.just
+>    #!/usr/bin/env bash
+#^^^^ source.just
+#    ^^^^^^^^^^^^^^^^^^^ source.just comment.line.number-sign.shebang.just
+>    echo "base indent"
+#^^^^ source.just source.shell meta.statement.shell
+#    ^^^^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.statement.command.name.shell entity.name.function.call.shell entity.name.command.shell support.function.builtin.shell
+#        ^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell
+#         ^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell string.quoted.double.shell punctuation.definition.string.begin.shell
+#          ^^^^^^^^^^^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell string.quoted.double.shell
+#                     ^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell string.quoted.double.shell punctuation.definition.string.end.shell
+>        echo "more indented"
+#^^^^^^^^ source.just source.shell meta.statement.shell
+#        ^^^^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.statement.command.name.shell entity.name.function.call.shell entity.name.command.shell support.function.builtin.shell
+#            ^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell
+#             ^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell string.quoted.double.shell punctuation.definition.string.begin.shell
+#              ^^^^^^^^^^^^^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell string.quoted.double.shell
+#                           ^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell string.quoted.double.shell punctuation.definition.string.end.shell
+>    echo "back to base"
+#^^^^ source.just source.shell meta.statement.shell
+#    ^^^^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.statement.command.name.shell entity.name.function.call.shell entity.name.command.shell support.function.builtin.shell
+#        ^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell
+#         ^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell string.quoted.double.shell punctuation.definition.string.begin.shell
+#          ^^^^^^^^^^^^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell string.quoted.double.shell
+#                      ^ source.just source.shell meta.statement.shell meta.statement.command.shell meta.argument.shell string.quoted.double.shell punctuation.definition.string.end.shell
+>


### PR DESCRIPTION
**Description:**

Re https://github.com/nefrob/vscode-just/issues/73.

- Fix shell HereDoc syntax highlighting bleeding into subsequent recipes by replacing `end` with `while` in embedded language rules. 

Thanks @RedCMD.

**Testing/Screenshots:**

<img width="335" height="386" alt="Screenshot 2026-03-28 at 11 19 47 AM" src="https://github.com/user-attachments/assets/a72f0659-6f61-447f-abdb-047a97ce0e4e" />
