### PR TITLE
🐛 Fix LSP "binary not found" when no workspace folder is open

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import * as os from 'os';
 import * as vscode from 'vscode';
 
 import { EXTENSION_NAME, SETTINGS } from './const';
@@ -16,7 +17,7 @@ export const workspaceRoot = (): string => {
   const workspaceFolders = vscode.workspace.workspaceFolders;
   return workspaceFolders && workspaceFolders.length > 0
     ? workspaceFolders[0].uri.fsPath
-    : '~';
+    : os.homedir();
 };
 
 export const getJustPath = (): string => {


### PR DESCRIPTION
## What changed
When a justfile is opened with no workspace folder (a loose file), the Just LSP no longer fails to start with a spurious `Just LSP binary not found at path: …` warning, even when `just-lsp` is installed and `vscode-just.lspPath` is correct.

## Why
`workspaceRoot()` fell back to the literal string `"~"` when there are no workspace folders. Node does not expand `~`, so it was passed as an invalid `cwd` to the `just-lsp --version` validation spawn (`src/lsp.ts`), which threw `ENOENT` — and the `error` handler misreported it as the binary being missing, regardless of `lspPath`. Reproduces exactly:

```js
spawn("/opt/homebrew/bin/just-lsp", ["--version"], { cwd: "~" }) // -> error: ENOENT
spawn("/opt/homebrew/bin/just-lsp", ["--version"], {})           // -> close 0 ✅
```

The fix returns `os.homedir()` — the real directory `"~"` was clearly meant to represent — so the return type stays `string` and every caller is unaffected.

## Things to look out for
`workspaceRoot()` is also the `cwd` for the recipe-runner and launcher spawns (`src/recipe.ts`, `src/launcher.ts`), so this additionally gives those a valid `cwd` (instead of `"~"`) when no folder is open.

## Related
Closes #104.
